### PR TITLE
feat: Introduce robust debugging with Bochs and improve build system

### DIFF
--- a/.bochsrc
+++ b/.bochsrc
@@ -1,0 +1,7 @@
+display_library: x, options="gui_debug"
+port_e9_hack: enabled=1
+magic_break: enabled=1
+romimage: file=/nix/store/rfflq573v0xs63hs3w8wlfgbahz25f7g-bochs-2.8/share/bochs/BIOS-bochs-latest
+vgaromimage: file=/nix/store/rfflq573v0xs63hs3w8wlfgbahz25f7g-bochs-2.8/share/bochs/VGABIOS-lgpl-latest
+boot: cdrom
+ata0-master: type=cdrom, path=kernel.iso, status=inserted

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 # Project
+*.ini
+isodir
+*.iso
 *.bin
 .cache/
 

--- a/grub.cfg
+++ b/grub.cfg
@@ -1,0 +1,6 @@
+menuentry "ferrite" {
+	multiboot /boot/ferrite-c.bin -root 8 0
+}
+
+set default=0
+set timeout=0

--- a/shell.nix
+++ b/shell.nix
@@ -6,13 +6,13 @@ let
       { };
 
   bochs-src = pinnedPkgs.fetchurl {
-    url = "https://downloads.sourceforge.net/project/bochs/bochs/2.8/bochs-2.8.tar.gz";
-    sha256 = "sha256-qFsTr/fYQR96nzVrpsM7X13B+7EH61AYzCOmJjnaAFk=";
+    url = "https://downloads.sourceforge.net/project/bochs/bochs/3.0/bochs-3.0.tar.gz";
+    sha256 = "sha256-y29UK1HzWizJIGsqmA21YCt80bfPLk7U8Ras1VB3gao=";
   };
 
   customBochs = pinnedPkgs.bochs.overrideAttrs (oldAttrs: {
-    name = "bochs-with-debugger-2.8"; # Give our custom version a new name
-    src = bochs-src; # Replace the source with the one we just fetched
+    name = "bochs-with-debugger";
+    src = bochs-src;
 
     configureFlags = oldAttrs.configureFlags ++ [
       "--enable-debugger"

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,38 @@ let
     import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-24.11.tar.gz")
       { };
 
+  bochs-src = pinnedPkgs.fetchurl {
+    url = "https://downloads.sourceforge.net/project/bochs/bochs/2.8/bochs-2.8.tar.gz";
+    sha256 = "sha256-qFsTr/fYQR96nzVrpsM7X13B+7EH61AYzCOmJjnaAFk=";
+  };
+
+  customBochs = pinnedPkgs.bochs.overrideAttrs (oldAttrs: {
+    name = "bochs-with-debugger-2.8"; # Give our custom version a new name
+    src = bochs-src; # Replace the source with the one we just fetched
+
+    configureFlags = oldAttrs.configureFlags ++ [
+      "--enable-debugger"
+      "--enable-smp"
+      "--enable-cpu-level=6"
+      "--enable-all-optimizations"
+      "--enable-x86-64"
+      "--enable-pci"
+      "--enable-vmx"
+      "--enable-debugger-gui"
+      "--enable-logging"
+      "--enable-fpu"
+      "--enable-3dnow"
+      "--enable-sb16=dummy"
+      "--enable-cdrom"
+      "--enable-x86-debugger"
+      "--enable-iodebug"
+      "--disable-plugins"
+      "--disable-docbook"
+      "--with-x11"
+      "--with-term"
+    ];
+  });
+
   crossToolchain = pinnedPkgs.pkgsCross.i686-embedded.buildPackages.gcc;
 
 in
@@ -17,21 +49,16 @@ pinnedPkgs.mkShell {
     binutils
     xorriso
     clang-tools
-
     pkg-config
     mdbook
-
-    # Formatters
-    markdownlint-cli
-    alejandra
-
-    # Other
     grub2
     bear
     tree
+
+    customBochs
   ];
 
   shellHook = ''
-    echo "✅ Development environment from nixpkgs 23.11 is ready!"
+    echo "✅ Development environment with custom-built Bochs is ready!"
   '';
 }

--- a/src/debug/debug.h
+++ b/src/debug/debug.h
@@ -1,0 +1,17 @@
+#ifndef DEBUG_H
+#define DEBUG_H
+
+#include "arch/x86/io.h"
+
+#define BOCHS_BREAK()                                                          \
+  outw(0x8A00, 0x8A00);                                                        \
+  outw(0x8A00, 0x08AE0);
+#define BOCHS_MAGICBREAK() __asm__ __volatile__("xchg %bx, %bx");
+
+static inline void bochs_print_string(const char *str) {
+  for (int i = 0; str[i] != '\0'; i++) {
+    outb(0xe9, str[i]);
+  }
+}
+
+#endif /* DEBUG_H */

--- a/src/drivers/serial.c
+++ b/src/drivers/serial.c
@@ -1,0 +1,44 @@
+#include "arch/x86/io.h"
+#include "lib/stdlib.h"
+
+#include <stdint.h>
+
+const uint16_t PORT = 0x3f8;
+
+/* Private */
+
+static uint8_t is_transmit_empty() { return inb(PORT + 5) & 0x20; }
+
+static void serial_write_byte(uint8_t a) {
+  while (is_transmit_empty() == 0) {
+  }
+
+  outb(PORT, a);
+}
+
+/* Public */
+
+void serial_write_string(char *s) {
+  for (int32_t i = 0; s[i]; i++) {
+    serial_write_byte(s[i]);
+  }
+}
+
+void serial_init(void) {
+  outb(PORT + 1, 0x00); // Disable all interrupts
+  outb(PORT + 3, 0x80); // Enable DLAB (set baud rate divisor)
+  outb(PORT, 0x03);     // Set divisor to 3 (lo byte) 38400 baud
+  outb(PORT + 1, 0x00); //                  (hi byte)
+  outb(PORT + 3, 0x03); // 8 bits, no parity, one stop bit
+  outb(PORT + 2, 0xc7); // Enable FIFO, clear them, with 14-byte threshold
+  outb(PORT + 4, 0x0b); // IRQs enabled, RTS/DSR set
+  outb(PORT + 4, 0x1e); // Set in loopback mode, test the serial chip
+  outb(PORT, 0xae);     // Test serial chip (send byte 0xAE and check if serial
+                        // returns same byte)
+
+  if (inb(PORT) != 0xae) {
+    abort("Port unusable");
+  }
+
+  outb(PORT + 4, 0x0f);
+}

--- a/src/drivers/serial.h
+++ b/src/drivers/serial.h
@@ -1,0 +1,8 @@
+#ifndef SERIAL_H
+#define SERIAL_H
+
+void serial_init(void);
+
+void serial_write_string(char *s);
+
+#endif /* SERIAL_H */

--- a/src/lib/stdlib.h
+++ b/src/lib/stdlib.h
@@ -1,6 +1,6 @@
 #ifndef _STDLIB_H
 #define _STDLIB_H 1
 
-__attribute__((__noreturn__)) void abort(void);
+__attribute__((__noreturn__)) void abort(char *);
 
 #endif

--- a/src/lib/stdlib/abort.c
+++ b/src/lib/stdlib/abort.c
@@ -1,12 +1,12 @@
-
 #if defined(__is_libk)
 #include "drivers/printk.h"
 #endif
 
-__attribute__((__noreturn__)) void abort(void) {
+__attribute__((__noreturn__)) void abort(char *err) {
 #if defined(__is_libk)
   // TODO: Add proper kernel panic.
-  printk("kernel: panic: abort()\n");
+  printk("kernel: panic: %s\n", err);
+  printk("abort()\n");
   __asm__ __volatile__("hlt");
 #else
   // TODO: Abnormally terminate the process as if by SIGABRT.


### PR DESCRIPTION
This pull request significantly enhances the development and debugging workflow by introducing Bochs as a primary debugging target and overhauling the build system for greater flexibility and realism.

Previously, debugging was limited to QEMU's GDB stub. This update adds a comprehensive Bochs setup, complete with a custom Nix build to enable its powerful internal debugger, and refactors the build process to use a GRUB-booted ISO image, more closely mirroring a real hardware environment.

#### Key Changes:

* **Bochs Integration (`.bochsrc`, `shell.nix`):**
    * Adds a `.bochsrc` configuration file to set up the Bochs environment, enabling the GUI debugger and `magic_break`.
    * Updates `shell.nix` to build a custom version of **Bochs 3.0** from source, with the debugger, GUI, and all necessary features enabled. This provides a consistent and powerful debugging tool within the Nix environment.

* **ISO-based Booting (`Makefile`, `grub.cfg`):**
    * The `Makefile` is updated to generate a bootable `kernel.iso` file using `grub-mkrescue`.
    * The `run` and `debug` targets now boot from this ISO image instead of using QEMU's `-kernel` flag, providing a more realistic boot sequence.
    * A `grub.cfg` file is added to configure the Multiboot entry for the kernel.

* **Makefile Overhaul:**
    * Introduces new targets: `iso`, `debug_bochs`, and `test`.
    * Adds a `fclean` target to remove all generated files, including the ISO and `isodir`.
    * Enables debug symbols (`-g`) in `CFLAGS` for better GDB/Bochs source-level debugging.
    * Adds a `__print_serial` CFLAG to control serial port debugging output.

* **Debugging Helpers (`debug.h`):**
    * Adds a new `debug.h` header with convenience macros for debugging in Bochs:
        * `BOCHS_MAGICBREAK()` (`xchg %bx, %bx`) for setting breakpoints in code that Bochs can trap.
        * `bochs_print_string()` for easy string logging via the E9 port hack.

This foundational work moves the project towards a more professional development environment, enabling deeper and more accurate debugging of low-level and hardware-interactive code.