### PR TITLE
feat: Add PIC handling and interrupt-driven keyboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SDIR = ./src
 ODIR = ./build
 
 CFLAGS = -I$(SDIR) -m32 -ffreestanding -g -O2 -Wall -Wextra -Werror \
-         -fno-stack-protector -D__is_libk -D__print_serial -pedantic -std=c99 -march=i386
+         -fno-stack-protector -D__is_libk -D__print_serial -D__bochs -pedantic -std=c99 -march=i386
 ASFLAGS = -felf32
 LDFLAGS = -T $(SDIR)/arch/x86/x86.ld -ffreestanding -nostdlib -lgcc -march=i386
 

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -14,6 +14,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/lib/stdlib/abort.o",
       "src/lib/stdlib/abort.c"
@@ -37,6 +40,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/lib/string/memset.o",
       "src/lib/string/memset.c"
@@ -60,6 +66,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/lib/string/strcmp.o",
       "src/lib/string/strcmp.c"
@@ -83,6 +92,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/lib/string/strlen.o",
       "src/lib/string/strlen.c"
@@ -106,6 +118,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/lib/string/memmove.o",
       "src/lib/string/memmove.c"
@@ -129,6 +144,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/drivers/video/vga_text.o",
       "src/drivers/video/vga_text.c"
@@ -152,6 +170,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/drivers/keyboard.o",
       "src/drivers/keyboard.c"
@@ -175,6 +196,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/drivers/serial.o",
       "src/drivers/serial.c"
@@ -198,6 +222,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/drivers/console.o",
       "src/drivers/console.c"
@@ -221,6 +248,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/drivers/printk.o",
       "src/drivers/printk.c"
@@ -244,6 +274,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/kernel.o",
       "src/kernel.c"
@@ -267,6 +300,61 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
+      "-o",
+      "build/arch/x86/idt/exceptions.o",
+      "src/arch/x86/idt/exceptions.c"
+    ],
+    "directory": "/home/xannyx/Documents/ideaProjects/ferrite-c",
+    "file": "/home/xannyx/Documents/ideaProjects/ferrite-c/src/arch/x86/idt/exceptions.c",
+    "output": "/home/xannyx/Documents/ideaProjects/ferrite-c/build/arch/x86/idt/exceptions.o"
+  },
+  {
+    "arguments": [
+      "/nix/store/x3bl1vw9wvs2vjn1ijnrfi8y1j7fcnlc-i686-elf-gcc-wrapper-13.3.0/bin/i686-elf-gcc",
+      "-c",
+      "-I./src",
+      "-m32",
+      "-ffreestanding",
+      "-g",
+      "-O2",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-fno-stack-protector",
+      "-D__is_libk",
+      "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
+      "-o",
+      "build/arch/x86/idt/idt.o",
+      "src/arch/x86/idt/idt.c"
+    ],
+    "directory": "/home/xannyx/Documents/ideaProjects/ferrite-c",
+    "file": "/home/xannyx/Documents/ideaProjects/ferrite-c/src/arch/x86/idt/idt.c",
+    "output": "/home/xannyx/Documents/ideaProjects/ferrite-c/build/arch/x86/idt/idt.o"
+  },
+  {
+    "arguments": [
+      "/nix/store/x3bl1vw9wvs2vjn1ijnrfi8y1j7fcnlc-i686-elf-gcc-wrapper-13.3.0/bin/i686-elf-gcc",
+      "-c",
+      "-I./src",
+      "-m32",
+      "-ffreestanding",
+      "-g",
+      "-O2",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-fno-stack-protector",
+      "-D__is_libk",
+      "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/arch/x86/gdt/gdt.o",
       "src/arch/x86/gdt/gdt.c"
@@ -290,13 +378,16 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
-      "build/boot/bootmain.o",
-      "src/boot/bootmain.c"
+      "build/memory/ksize.o",
+      "src/memory/ksize.c"
     ],
     "directory": "/home/xannyx/Documents/ideaProjects/ferrite-c",
-    "file": "/home/xannyx/Documents/ideaProjects/ferrite-c/src/boot/bootmain.c",
-    "output": "/home/xannyx/Documents/ideaProjects/ferrite-c/build/boot/bootmain.o"
+    "file": "/home/xannyx/Documents/ideaProjects/ferrite-c/src/memory/ksize.c",
+    "output": "/home/xannyx/Documents/ideaProjects/ferrite-c/build/memory/ksize.o"
   },
   {
     "arguments": [
@@ -313,6 +404,35 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
+      "-o",
+      "build/memory/kfree.o",
+      "src/memory/kfree.c"
+    ],
+    "directory": "/home/xannyx/Documents/ideaProjects/ferrite-c",
+    "file": "/home/xannyx/Documents/ideaProjects/ferrite-c/src/memory/kfree.c",
+    "output": "/home/xannyx/Documents/ideaProjects/ferrite-c/build/memory/kfree.o"
+  },
+  {
+    "arguments": [
+      "/nix/store/x3bl1vw9wvs2vjn1ijnrfi8y1j7fcnlc-i686-elf-gcc-wrapper-13.3.0/bin/i686-elf-gcc",
+      "-c",
+      "-I./src",
+      "-m32",
+      "-ffreestanding",
+      "-g",
+      "-O2",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-fno-stack-protector",
+      "-D__is_libk",
+      "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/memory/pmm.o",
       "src/memory/pmm.c"
@@ -336,6 +456,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/memory/vmm.o",
       "src/memory/vmm.c"
@@ -359,6 +482,9 @@
       "-fno-stack-protector",
       "-D__is_libk",
       "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
       "-o",
       "build/memory/kmalloc.o",
       "src/memory/kmalloc.c"
@@ -366,5 +492,31 @@
     "directory": "/home/xannyx/Documents/ideaProjects/ferrite-c",
     "file": "/home/xannyx/Documents/ideaProjects/ferrite-c/src/memory/kmalloc.c",
     "output": "/home/xannyx/Documents/ideaProjects/ferrite-c/build/memory/kmalloc.o"
+  },
+  {
+    "arguments": [
+      "/nix/store/x3bl1vw9wvs2vjn1ijnrfi8y1j7fcnlc-i686-elf-gcc-wrapper-13.3.0/bin/i686-elf-gcc",
+      "-c",
+      "-I./src",
+      "-m32",
+      "-ffreestanding",
+      "-g",
+      "-O2",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-fno-stack-protector",
+      "-D__is_libk",
+      "-D__print_serial",
+      "-pedantic",
+      "-std=c99",
+      "-march=i386",
+      "-o",
+      "build/memory/kbrk.o",
+      "src/memory/kbrk.c"
+    ],
+    "directory": "/home/xannyx/Documents/ideaProjects/ferrite-c",
+    "file": "/home/xannyx/Documents/ideaProjects/ferrite-c/src/memory/kbrk.c",
+    "output": "/home/xannyx/Documents/ideaProjects/ferrite-c/build/memory/kbrk.o"
   }
 ]

--- a/src/arch/x86/idt/exceptions.c
+++ b/src/arch/x86/idt/exceptions.c
@@ -1,6 +1,7 @@
 #include "arch/x86/idt/idt.h"
 #include "arch/x86/io.h"
 #include "arch/x86/pic.h"
+#include "debug/debug.h"
 #include "drivers/console.h"
 #include "drivers/keyboard.h"
 #include "drivers/printk.h"
@@ -36,6 +37,7 @@ debug_interrupt_handler(struct interrupt_frame *frame) {
   (void)frame;
 
   printk("EXCEPTION: DEBUG EXCEPTION (#DB)\n");
+  BOCHS_BREAK();
 }
 
 __attribute__((target("general-regs-only"))) __attribute__((interrupt)) void
@@ -49,7 +51,7 @@ __attribute__((target("general-regs-only"))) __attribute__((interrupt)) void
 breakpoint_handler(struct interrupt_frame *frame) {
   (void)frame;
 
-  __asm__ volatile("cli; hlt");
+  BOCHS_BREAK();
 }
 
 __attribute__((target("general-regs-only"))) __attribute__((interrupt)) void

--- a/src/arch/x86/idt/idt.c
+++ b/src/arch/x86/idt/idt.c
@@ -51,6 +51,8 @@ void idt_init(void) {
     idt_set_gate(i, handler);
   }
 
+  idt_set_gate(0x21, (uint32_t)keyboard_handler);
+
   idt_ptr.limit = sizeof(entry_t) * IDT_ENTRY_COUNT - 1;
   idt_ptr.base = (uint32_t)&idt_entries;
 

--- a/src/arch/x86/idt/idt.h
+++ b/src/arch/x86/idt/idt.h
@@ -64,6 +64,9 @@ void page_fault(struct interrupt_frame *frame, uint32_t error_code);
 void alignment_check(struct interrupt_frame *frame, uint32_t error_code);
 void security_exception(struct interrupt_frame *frame, uint32_t error_code);
 
-void idt_init();
+// --- Hardware Interrupts ---
+void keyboard_handler(struct interrupt_frame *frame);
+
+void idt_init(void);
 
 #endif /* IDT_H */

--- a/src/arch/x86/io.h
+++ b/src/arch/x86/io.h
@@ -33,4 +33,6 @@ static inline void outl(uint16_t addr, uint32_t val) {
   __asm__ __volatile__("outl %1, %0" : : "d"(addr), "a"(val));
 }
 
+static inline void io_wait(void) { outb(0x80, 0); }
+
 #endif /* IO_H */

--- a/src/arch/x86/pic.c
+++ b/src/arch/x86/pic.c
@@ -1,0 +1,33 @@
+#include "arch/x86/pic.h"
+#include "arch/x86/io.h"
+
+void pic_remap(int32_t offset1, int32_t offset2) {
+  // starts the initialization sequence (in cascade mode)
+  outb(PIC1_COMMAND, ICW1_INIT | ICW1_ICW4);
+  io_wait();
+  outb(PIC2_COMMAND, ICW1_INIT | ICW1_ICW4);
+  io_wait();
+
+  outb(PIC1_DATA, offset1); // ICW2: Master PIC vector offset
+  io_wait();
+  outb(PIC2_DATA, offset2); // ICW2: Slave PIC vector offset
+  io_wait();
+
+  // ICW3: tell Master PIC that there is a slave PIC at IRQ2 (0000 0100)
+  outb(PIC1_DATA, 4);
+  io_wait();
+
+  // ICW3: tell Slave PIC its cascade identity (0000 0010)
+  outb(PIC2_DATA, 2);
+  io_wait();
+
+  // ICW4: have the PICs use 8086 mode (and not 8080 mode)
+  outb(PIC1_DATA, ICW4_8086);
+  io_wait();
+  outb(PIC2_DATA, ICW4_8086);
+  io_wait();
+
+  // Unmask both PICs.
+  outb(PIC2_DATA, 0xFF);
+  outb(PIC1_DATA, 0xFD);
+}

--- a/src/arch/x86/pic.h
+++ b/src/arch/x86/pic.h
@@ -1,0 +1,43 @@
+#ifndef PIC_H
+#define PIC_H
+
+#include "arch/x86/io.h"
+#include <stdint.h>
+
+#define PIC1 0x20 /* IO base address for master PIC */
+#define PIC2 0xA0 /* IO base address for slave PIC */
+#define PIC1_COMMAND PIC1
+#define PIC1_DATA (PIC1 + 1)
+#define PIC2_COMMAND PIC2
+#define PIC2_DATA (PIC2 + 1)
+
+#define ICW1_ICW4 0x01      /* Indicates that ICW4 will be present */
+#define ICW1_SINGLE 0x02    /* Single (cascade) mode */
+#define ICW1_INTERVAL4 0x04 /* Call address interval 4 (8) */
+#define ICW1_LEVEL 0x08     /* Level triggered (edge) mode */
+#define ICW1_INIT 0x10      /* Initialization - required! */
+
+#define ICW4_8086 0x01       /* 8086/88 (MCS-80/85) mode */
+#define ICW4_AUTO 0x02       /* Auto (normal) EOI */
+#define ICW4_BUF_SLAVE 0x08  /* Buffered mode/slave */
+#define ICW4_BUF_MASTER 0x0C /* Buffered mode/master */
+#define ICW4_SFNM 0x10       /* Special fully nested (not) */
+
+#ifndef EOI_H
+#define EOI_H
+
+void pic_remap(int32_t, int32_t);
+
+#define PIC_EOI 0x20 /* End-of-interrupt command code */
+
+static inline void pic_send_eoi(uint8_t irq) {
+  if (irq & 8) {
+    outb(PIC2_COMMAND, PIC_EOI);
+  }
+
+  outb(PIC1_COMMAND, PIC_EOI);
+}
+
+#endif /* EOI_H */
+
+#endif /* PIC_H */

--- a/src/drivers/keyboard.c
+++ b/src/drivers/keyboard.c
@@ -39,26 +39,20 @@ char scancode_to_ascii(uint8_t scan_code, bool shift_pressed) {
   return scancode_map_no_shift[scan_code];
 }
 
-char keyboard_input() {
-  if ((inb(KEYBOARD_STATUS_PORT) & 1) == 0) {
-    return '\0';
-  }
-
-  uint8_t scan_code = inb(KEYBOARD_DATA_PORT);
-
+char keyboard_input(uint8_t scancode) {
   // Shift Pressed
-  if (scan_code == 42) {
+  if (scancode == 42) {
     SHIFT_PRESSED = true;
     return 0;
   }
 
   // Shift Released
-  if (scan_code == 170) {
+  if (scancode == 170) {
     SHIFT_PRESSED = false;
     return 0;
   }
 
-  char c = scancode_to_ascii(scan_code, SHIFT_PRESSED);
+  char c = scancode_to_ascii(scancode, SHIFT_PRESSED);
 
   return c;
 }

--- a/src/drivers/keyboard.h
+++ b/src/drivers/keyboard.h
@@ -2,6 +2,7 @@
 #define KEYBOARD_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef enum keyboard_key {
   KeyEsc = 0x01,
@@ -131,6 +132,6 @@ typedef enum keyboard_key {
   KeyPause = 0xef,
 } keyboard_key_t;
 
-char keyboard_input();
+char keyboard_input(uint8_t scancode);
 
 #endif /* KEYBOARD_H */

--- a/src/lib/string.h
+++ b/src/lib/string.h
@@ -3,7 +3,9 @@
 
 #include <stddef.h>
 
-static inline size_t strlen(const char *s);
+size_t strlen(const char *s);
+
+void *memcpy(void *dest, const void *src, size_t n);
 
 void *memmove(void *dest, const void *src, size_t len);
 

--- a/src/lib/string/memcpy.c
+++ b/src/lib/string/memcpy.c
@@ -1,0 +1,17 @@
+#include <stddef.h>
+#include <stdint.h>
+
+void *memcpy(void *dest, const void *src, size_t n) {
+  uint8_t *d = dest;
+  const uint8_t *s = src;
+
+  if (src || dest) {
+    while (n) {
+      n--;
+      *d = *s;
+      d++;
+      s++;
+    }
+  }
+  return (dest);
+}


### PR DESCRIPTION
This PR transitions the kernel from a polling-based model to an interrupt-driven one by implementing handlers for the Programmable Interrupt Controller (PIC) and keyboard.

### Description

This is a foundational architectural change that moves the kernel towards a more modern, event-driven design. It introduces a complete PIC initialization routine and refactors the keyboard driver to respond to hardware interrupts instead of relying on a busy-wait loop.

#### Key Changes:

* **PIC Initialization:**
    * Adds `pic_remap()` to initialize and remap the Master and Slave PICs, moving hardware IRQs to a safe vector range (32-47) to avoid conflicts with CPU exceptions.
    * Correctly masks interrupts during initialization, enabling only **IRQ 1** (keyboard) to prevent crashes from unhandled interrupts like the system timer.

* **Interrupt-Driven Keyboard:**
    * The `keyboard_input()` function is refactored to be called from an Interrupt Service Routine (ISR).
    * A new `keyboard_handler` is registered at **interrupt vector 33 (0x21)** to handle keypresses.
    * The handler reads the scancode from port `0x60` and sends an **End of Interrupt (EOI)** signal to the PIC, allowing further interrupts to be processed.

* **Kernel Idle Loop:**
    * The main loop in `kmain` is replaced with an efficient idle loop (`for (;;) { hlt; }`).
    * Interrupts are now enabled via `sti` after all critical hardware is initialized, allowing the `hlt` instruction to wait for events like keypresses.