### PR TITLE
feat(x86): Add initial system call framework

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -2,8 +2,11 @@ CompileFlags:
   Compiler: i686-elf-gcc
 
 If:
-  PathMatch: 'src/arch/x86/idt/exceptions.c'
+  PathMatch:
+    - 'src/arch/x86/idt/exceptions.c'
+    - 'src/arch/x86/idt/syscalls.c'
 
 Diagnostics:
   Suppress:
     - excessive-regsave
+

--- a/src/arch/x86/gdt/gdt.c
+++ b/src/arch/x86/gdt/gdt.c
@@ -24,7 +24,7 @@ static void gdt_set_gate(uint32_t num, uint32_t base, uint32_t limit,
 
 /* Public */
 
-void gdt_init() {
+void gdt_init(void) {
   gdt_ptr.limit = sizeof(entry_t) * 5 - 1;
   gdt_ptr.base = (uint32_t)&gdt_entries;
 

--- a/src/arch/x86/gdt/gdt.h
+++ b/src/arch/x86/gdt/gdt.h
@@ -1,6 +1,6 @@
 #ifndef GDT_H
 #define GDT_H
 
-void gdt_init();
+void gdt_init(void);
 
 #endif /* GDT_H */

--- a/src/arch/x86/idt/idt.h
+++ b/src/arch/x86/idt/idt.h
@@ -36,6 +36,11 @@ typedef struct {
   } handler;
 } interrupt_handler_entry_t;
 
+typedef struct {
+  uint32_t hex;
+  interrupt_handler func;
+} interrupt_hardware_t;
+
 // --- Handlers that DO NOT have an error code ---
 void divide_by_zero_handler(registers_t *);
 void debug_interrupt_handler(registers_t *);

--- a/src/arch/x86/idt/syscall_handler.asm
+++ b/src/arch/x86/idt/syscall_handler.asm
@@ -1,0 +1,44 @@
+section .text
+global  syscall_handler
+
+	; This is the entry point for `int 0x80`
+
+syscall_handler:
+	push dword 0x80
+	push dword 0
+
+	push eax
+	push ecx
+	push edx
+	push ebx
+
+	push esp
+
+	push ebp
+	push esi
+	push edi
+
+	push ds
+
+	extern syscall_dispatcher_c
+	push   esp; Push the `registers_t frame` as the argument
+	call   syscall_dispatcher_c
+	add    esp, 4; Clean up the argument `registers_t`
+
+	pop ds
+
+	pop edi
+	pop esi
+	pop ebp
+	pop esp
+	pop ebx
+	pop edx
+	pop ecx
+
+	;    Handle EAX: Swap return value in EAX with original EAX on stack, then pop original.
+	xchg eax, [esp]; Swap current EAX (C function's return) with old EAX (syscall_num) on stack
+	pop  eax; Pop the original EAX (now containing the return value) into EAX
+
+	add esp, 8
+
+	iret

--- a/src/arch/x86/idt/syscalls.c
+++ b/src/arch/x86/idt/syscalls.c
@@ -1,0 +1,59 @@
+#include "syscalls.h"
+#include "arch/x86/idt/idt.h"
+#include "drivers/printk.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+// TODO: Make sys_exit function
+__attribute__((target("general-regs-only"))) static uint32_t
+sys_exit(int32_t status) {
+  printk("Status: %d\n", status);
+
+  __asm__ volatile("hlt");
+  return 0;
+}
+
+// TODO: Make _read function
+
+__attribute__((target("general-regs-only"), warn_unused_result)) static int32_t
+sys_read(int32_t fd, void *buf, size_t count) {
+  (void)fd;
+  (void)buf;
+  (void)count;
+
+  printk("Read\n");
+  return 0;
+}
+
+// TODO: Make _write function
+__attribute__((target("general-regs-only"), warn_unused_result)) static int32_t
+sys_write(int32_t fd, void *buf, size_t count) {
+  (void)fd;
+  (void)buf;
+  (void)count;
+
+  printk("Write\n");
+  return 0;
+}
+
+__attribute__((target("general-regs-only"))) void
+syscall_dispatcher_c(registers_t *reg) {
+  switch (reg->eax) {
+  case EXIT:
+    sys_exit(reg->ebx);
+    break;
+
+  case WRITE:
+    reg->eax = sys_write(reg->ebx, (void *)reg->ecx, reg->edx);
+    break;
+
+  case READ:
+    reg->eax = sys_read(reg->ebx, (void *)reg->ecx, reg->edx);
+    break;
+
+  default:
+    printk("Nothing...?\n");
+    return;
+  }
+}

--- a/src/arch/x86/idt/syscalls.h
+++ b/src/arch/x86/idt/syscalls.h
@@ -1,0 +1,12 @@
+#ifndef SYSCALLS_H
+#define SYSCALLS_H
+
+#include "arch/x86/idt/idt.h"
+
+#include <stddef.h>
+
+enum syscalls_e { EXIT, WRITE, READ, SYSCALL_COUNT };
+
+void syscall_dispatcher_c(registers_t *);
+
+#endif /* SYSCALLS_H */

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -15,10 +15,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#if defined(__linux__)
-#error "You are not using a cross-compiler"
-#endif
-
 #if !defined(__i386__)
 #error "This tutorial needs to be compiled with a ix86-elf compiler"
 #endif
@@ -39,15 +35,25 @@ __attribute__((noreturn)) void kmain(uint32_t magic, multiboot_info_t *mbd) {
 
   rtc_init();
 
-  kmalloc_init();
+  // kmalloc_init();
 
-  char *str = kmalloc(10);
-  memcpy(str, "Hello!", 10);
-  printk("%s\n", str);
+  // char *str = kmalloc(10);
+  // memcpy(str, "Hello!", 10);
+  // printk("%s\n", str);
 
-  kfree(str);
+  // kfree(str);
 
   console_init();
+
+  // int32_t syscall = 1;
+  // int32_t status = 1;
+  //
+  // __asm__ volatile("movl %0, %%eax\n\t"
+  //                  "movl %1, %%ebx\n\t"
+  //                  "int $0x80"
+  //                  :
+  //                  : "i"(syscall), "r"(status)
+  //                  : "eax", "ebx", "memory");
 
   __asm__ volatile("sti");
 


### PR DESCRIPTION
This PR introduces the foundational framework for handling system calls on the x86 architecture. This is a crucial step towards allowing user-space applications to interact with the kernel.

Key Changes
System Call Handler: A new interrupt gate is set up for int 0x80. This triggers a new assembly routine, syscall_handler.asm, which saves the current CPU state (registers) and prepares for a C-level function call.

C-level Dispatcher: A new file, syscalls.c, contains the syscall_dispatcher_c function. This function uses the eax register to determine the system call number and then dispatches the call to the appropriate kernel function (e.g., sys_exit, sys_write, sys_read).

Interrupt Descriptor Table (IDT) Refactoring: The IDT initialization logic in idt.c has been cleaned up. The old INTERRUPT_HANDLERS constant was renamed to EXCEPTION_HANDLERS, and a new HARDWARE_HANDLERS constant was introduced to separate exception handlers from hardware interrupt handlers.

Minor Code Style: The gdt_init function signature was updated to gdt_init(void) for improved clarity.

Build System: The .clangd configuration was updated to include the new syscalls.c file.

This framework provides a clear path for implementing and expanding kernel services that can be accessed by user applications.