### PR TITLE
refactor(mem): Change initiation of memory allocator

### DIFF
--- a/.bochsrc
+++ b/.bochsrc
@@ -4,3 +4,4 @@ magic_break: enabled=1
 boot: cdrom
 ata0-master: type=cdrom, path=kernel.iso, status=inserted
 memory: guest=8, host=256
+sound: waveoutdrv=dummy, midioutdrv=dummy

--- a/.bochsrc
+++ b/.bochsrc
@@ -3,3 +3,4 @@ port_e9_hack: enabled=1
 magic_break: enabled=1
 boot: cdrom
 ata0-master: type=cdrom, path=kernel.iso, status=inserted
+memory: guest=8, host=256

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -37,7 +37,9 @@ __attribute__((noreturn)) void kmain(uint32_t magic, multiboot_info_t *mbd) {
   pmm_init_from_map(mbd);
   memblock_init();
   buddy_init();
+
   vmm_init_pages();
+  memblock_deactivate();
   kmalloc_init();
 
   char *str = kmalloc(10);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -36,9 +36,9 @@ __attribute__((noreturn)) void kmain(uint32_t magic, multiboot_info_t *mbd) {
 
   pmm_init_from_map(mbd);
   memblock_init();
-  buddy_init();
 
   vmm_init_pages();
+  buddy_init();
   memblock_deactivate();
   kmalloc_init();
 

--- a/src/memory/buddy_allocator/buddy.c
+++ b/src/memory/buddy_allocator/buddy.c
@@ -210,8 +210,6 @@ void *buddy_alloc(uint32_t order) {
   uintptr_t block_addr = (uintptr_t)block_node;
 
   g_buddy.free_lists[k] = block_node->next;
-  printk("Block Addr: 0x%x\n", block_addr);
-  printk("Next: 0x%x\n", g_buddy.free_lists[k]);
   while (k > required_order) {
     uintptr_t buddy_addr = block_addr + (PAGE_SIZE * (1 << (k - 1)));
 
@@ -220,8 +218,6 @@ void *buddy_alloc(uint32_t order) {
   }
 
   mark_allocated(block_addr, required_order);
-
-  buddy_visualize();
 
   return (void *)block_addr;
 }

--- a/src/memory/consts.h
+++ b/src/memory/consts.h
@@ -1,11 +1,7 @@
 #ifndef CONSTS_H
 #define CONSTS_H
 
-#include <stdint.h>
-
 #define PAGE_SIZE 0x1000
-
-typedef uintptr_t phys_addr;
-typedef uintptr_t virt_addr;
+#define SCRATCH_VADDR ((void *)0xFFBFF000)
 
 #endif /* CONSTS_H */

--- a/src/memory/kmalloc.c
+++ b/src/memory/kmalloc.c
@@ -4,7 +4,6 @@
 #include "lib/stdlib.h"
 #include "memory/buddy_allocator/buddy.h"
 #include "memory/consts.h"
-#include "memory/pmm.h"
 #include "memory/vmm.h"
 
 #include <stddef.h>

--- a/src/memory/memblock.c
+++ b/src/memory/memblock.c
@@ -2,9 +2,11 @@
 #include "memory/consts.h"
 #include "memory/pmm.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
+static bool bumpalloc_is_active = false;
 static void *next_free_addr = NULL;
 static void *heap_end_addr = NULL;
 
@@ -13,6 +15,10 @@ static void *heap_end_addr = NULL;
 void *get_next_free_addr(void) { return next_free_addr; }
 
 void *get_heap_end_addr(void) { return heap_end_addr; }
+
+void memblock_deactivate(void) { bumpalloc_is_active = false; }
+
+bool memblock_is_active(void) { return bumpalloc_is_active; }
 
 /*
  * FIXME: This implementation only uses the first available memory region and
@@ -29,6 +35,7 @@ void *get_heap_end_addr(void) { return heap_end_addr; }
 void memblock_init(void) {
   next_free_addr = (void *)pmm_get_first_addr();
   heap_end_addr = (void *)(pmm_bitmap_len() * PAGE_SIZE * 8);
+  bumpalloc_is_active = true;
 }
 
 /*

--- a/src/memory/memblock.h
+++ b/src/memory/memblock.h
@@ -1,6 +1,7 @@
 #ifndef MEMBLOCK_H
 #define MEMBLOCK_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 void memblock_init(void);
@@ -10,5 +11,9 @@ void *memblock(size_t);
 void *get_next_free_addr(void);
 
 void *get_heap_end_addr(void);
+
+void memblock_deactivate(void);
+void memblock_activate(void);
+bool memblock_is_active(void);
 
 #endif /* MEMBLOCK_H */

--- a/src/memory/vmm.c
+++ b/src/memory/vmm.c
@@ -1,7 +1,6 @@
 #include "memory/vmm.h"
 #include "arch/x86/memlayout.h"
 #include "debug/debug.h"
-#include "drivers/printk.h"
 #include "lib/stdlib.h"
 #include "memory/buddy_allocator/buddy.h"
 #include "memory/consts.h"
@@ -90,13 +89,11 @@ void vmm_init_pages(void) {
   }
 
   void *pt_phys_addr = memblock(PAGE_SIZE);
-  printk("Ptr: 0x%x\n", pt_phys_addr);
   if (!pt_phys_addr) {
     abort("Out of physical memory when allocating initial page table");
   }
 
-  uint32_t pt_virt_addr = P2V_WO((uintptr_t)pt_phys_addr);
-  uint32_t *pt = (uint32_t *)pt_virt_addr;
+  uint32_t *pt = (uint32_t *)P2V_WO((uintptr_t)pt_phys_addr);
   for (uint32_t i = 0; i < 1024; i++) {
     uint32_t page_phys_addr = i * PAGE_SIZE;
     pt[i] = page_phys_addr | PAGE_FLAG_PRESENT | PAGE_FLAG_WRITABLE |

--- a/src/memory/vmm.h
+++ b/src/memory/vmm.h
@@ -15,4 +15,6 @@ void vmm_init_pages(void);
 
 void *vmm_unmap_page(void *);
 
+void vmm_remap_page(void *vaddr, void *paddr, int32_t flags);
+
 #endif /* VMM_H */


### PR DESCRIPTION
This resolves a circular dependency between the Virtual Memory Manager (VMM) and the buddy allocator during initialization. The VMM needed an allocator to create its initial page tables, but the buddy allocator required the VMM to be active to access its metadata.

This is fixed by introducing a two-stage allocation strategy:

* A simple **bump allocator (`memblock`)** is now used for early boot allocations (e.g., for VMM page tables).
* The buddy allocator is refactored to use a **scratch virtual address (`SCRATCH_VADDR`)** to temporarily map and safely modify its free-list nodes in physical memory.
* The kernel initialization order is updated to use `memblock` first, initialize the VMM and buddy allocator, and then **deactivate `memblock`**.