### PR TITLE
feat(mm): Overhaul memory management with kmalloc/vmalloc split

### DIFF
--- a/.bochsrc
+++ b/.bochsrc
@@ -3,5 +3,5 @@ port_e9_hack: enabled=1
 magic_break: enabled=1
 boot: cdrom
 ata0-master: type=cdrom, path=kernel.iso, status=inserted
-memory: guest=8, host=256
+memory: guest=4, host=128
 sound: waveoutdrv=dummy, midioutdrv=dummy

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SDIR = ./src
 ODIR = ./build
 
 CFLAGS = -I$(SDIR) -m32 -ffreestanding -g -O2 -Wall -Wextra -Werror \
-         -fno-stack-protector -D__is_libk -D__print_serial -D__bochs -pedantic -std=c99 -march=i386
+         -fno-stack-protector -D__is_libk -D__print_serial -D__bochs -pedantic -std=c17 -march=i386
 ASFLAGS = -felf32
 LDFLAGS = -T $(SDIR)/arch/x86/x86.ld -ffreestanding -nostdlib -lgcc -march=i386
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -42,7 +42,6 @@ __attribute__((noreturn)) void kmain(uint32_t magic, multiboot_info_t *mbd) {
   buddy_init();
   memblock_deactivate();
   // vmalloc_init();
-  kmalloc_init();
 
   char *str = kmalloc(10);
   memcpy(str, "Hello!", 10);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -41,17 +41,7 @@ __attribute__((noreturn)) void kmain(uint32_t magic, multiboot_info_t *mbd) {
   vmm_init_pages();
   buddy_init();
   memblock_deactivate();
-  // vmalloc_init();
-
-  char *str = kmalloc(10);
-  memcpy(str, "Hello!", 10);
-  printk("%s\n", str);
-
-  // char *str = vmalloc(10);
-  // memcpy(str, "Hello!", 10);
-  // printk("%s\n", str);
-  //
-  // vfree(str);
+  vmalloc_init();
 
   console_init();
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -7,6 +7,7 @@
 #include "drivers/video/vga.h"
 #include "lib/stdlib.h"
 #include "memory/buddy_allocator/buddy.h"
+#include "memory/kmalloc.h"
 #include "memory/memblock.h"
 #include "memory/pmm.h"
 #include "memory/vmalloc.h"
@@ -40,19 +41,18 @@ __attribute__((noreturn)) void kmain(uint32_t magic, multiboot_info_t *mbd) {
   vmm_init_pages();
   buddy_init();
   memblock_deactivate();
-  vmalloc_init();
+  // vmalloc_init();
+  kmalloc_init();
 
-  char *str = vmalloc(10);
+  char *str = kmalloc(10);
   memcpy(str, "Hello!", 10);
   printk("%s\n", str);
 
-  vfree(str);
-
-  char *ptr = vmalloc(100);
-  memcpy(ptr, "Hello!", 10);
-  printk("%s\n", ptr);
-
-  vfree(ptr);
+  // char *str = vmalloc(10);
+  // memcpy(str, "Hello!", 10);
+  // printk("%s\n", str);
+  //
+  // vfree(str);
 
   console_init();
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -7,9 +7,9 @@
 #include "drivers/video/vga.h"
 #include "lib/stdlib.h"
 #include "memory/buddy_allocator/buddy.h"
-#include "memory/kmalloc.h"
 #include "memory/memblock.h"
 #include "memory/pmm.h"
+#include "memory/vmalloc.h"
 #include "memory/vmm.h"
 #include "sys/tasks.h"
 
@@ -40,13 +40,19 @@ __attribute__((noreturn)) void kmain(uint32_t magic, multiboot_info_t *mbd) {
   vmm_init_pages();
   buddy_init();
   memblock_deactivate();
-  kmalloc_init();
+  vmalloc_init();
 
-  char *str = kmalloc(10);
+  char *str = vmalloc(10);
   memcpy(str, "Hello!", 10);
   printk("%s\n", str);
 
-  kfree(str);
+  vfree(str);
+
+  char *ptr = vmalloc(100);
+  memcpy(ptr, "Hello!", 10);
+  printk("%s\n", ptr);
+
+  vfree(ptr);
 
   console_init();
 

--- a/src/lib/math.h
+++ b/src/lib/math.h
@@ -18,4 +18,12 @@ static inline uint32_t log2(uint32_t n) {
   return (sizeof(uint32_t) * 8 - 1) - __builtin_clz(n);
 }
 
+static inline uint32_t log2_rounded_up(uint32_t n) {
+  if (unlikely(n == 0)) {
+    __builtin_trap();
+  }
+
+  return (sizeof(uint32_t) * 8) - __builtin_clz(n - 1);
+}
+
 #endif /* MATH_H */

--- a/src/lib/math.h
+++ b/src/lib/math.h
@@ -1,11 +1,21 @@
 #ifndef MATH_H
 #define MATH_H
 
-#define ALIGN(x, a) (((x) + ((a) - 1)) & ~((a) - 1))
+#include <stdbool.h>
+#include <stdint.h>
 
+#define likely(x) __builtin_expect(!!(x), true)
+#define unlikely(x) __builtin_expect(!!(x), false)
+
+#define ALIGN(x, a) (((x) + ((a) - 1)) & ~((a) - 1))
 #define CEIL_DIV(a, b) (((a + b - 1) / b))
 
-/* #define LOG10(x) (())
-#define LOG2(x) ((LOG10(x) / LOG10(2))) */
+static inline uint32_t log2(uint32_t n) {
+  if (unlikely(n == 0)) {
+    __builtin_trap();
+  }
+
+  return (sizeof(uint32_t) * 8 - 1) - __builtin_clz(n);
+}
 
 #endif /* MATH_H */

--- a/src/memory/buddy_allocator/buddy.c
+++ b/src/memory/buddy_allocator/buddy.c
@@ -217,14 +217,13 @@ void *buddy_alloc(uint32_t order) {
 
   while (k > order) {
     k -= 1;
-    uintptr_t buddy_addr = block_addr + (PAGE_SIZE * (1 << k));
+    uintptr_t buddy_addr = block_addr + (PAGE_SIZE << k);
 
     buddy_list_add(buddy_addr, k);
   }
 
   mark_allocated(block_addr, order);
-  buddy_visualize();
-
+  // buddy_visualize();
   return (void *)block_addr;
 }
 

--- a/src/memory/kfree.c
+++ b/src/memory/kfree.c
@@ -4,10 +4,12 @@
 #include "memory/buddy_allocator/buddy.h"
 #include "memory/consts.h"
 #include "memory/kmalloc.h"
+#include "memory/memory.h"
 #include "memory/vmm.h"
 
 #include <stdint.h>
 
+// FIXME: FIXME
 void kfree(void *ptr) {
   if (!ptr) {
     printk("ptr is null\n");
@@ -26,7 +28,8 @@ void kfree(void *ptr) {
   free_list_t *freed_block = (free_list_t *)block_vaddr;
   freed_block->size = block_size;
 
-  free_list_t *current = get_free_list_head();
+  free_list_t *current = NULL;
+  // free_list_t *current = get_free_list_head();
   free_list_t *prev = NULL;
 
   while (current && (uintptr_t)current < (uintptr_t)freed_block) {
@@ -41,7 +44,8 @@ void kfree(void *ptr) {
     if (prev) {
       prev->next = freed_block;
     } else {
-      set_free_list_head(freed_block);
+
+      // set_free_list_head(freed_block);
     }
   }
 

--- a/src/memory/kfree.c
+++ b/src/memory/kfree.c
@@ -20,6 +20,10 @@ void kfree(void *ptr) {
     abort("The given pointer is corrupt\n");
   }
 
+  if ((header->flags & MEM_ALLOCATOR_MASK) != MEM_TYPE_KMALLOC) {
+    abort("kfree() is used on a vmalloc() pointer\n");
+  }
+
   uintptr_t vaddr = (uintptr_t)header;
   size_t size = header->size;
   uint32_t pages = CEIL_DIV(size, PAGE_SIZE);

--- a/src/memory/kfree.c
+++ b/src/memory/kfree.c
@@ -1,15 +1,14 @@
 #include "arch/x86/memlayout.h"
 #include "drivers/printk.h"
+#include "lib/math.h"
 #include "lib/stdlib.h"
 #include "memory/buddy_allocator/buddy.h"
 #include "memory/consts.h"
 #include "memory/kmalloc.h"
 #include "memory/memory.h"
-#include "memory/vmm.h"
 
 #include <stdint.h>
 
-// FIXME: FIXME
 void kfree(void *ptr) {
   if (!ptr) {
     printk("ptr is null\n");
@@ -18,50 +17,14 @@ void kfree(void *ptr) {
 
   block_header_t *header = (block_header_t *)ptr - 1;
   if (header->magic != MAGIC) {
-    printk("Ptr is corrupt\n");
-    return;
+    abort("The given pointer is corrupt\n");
   }
 
-  uintptr_t block_vaddr = (uintptr_t)header;
-  size_t block_size = header->size;
+  uintptr_t vaddr = (uintptr_t)header;
+  size_t size = header->size;
+  uint32_t pages = CEIL_DIV(size, PAGE_SIZE);
+  uint32_t order = log2_rounded_up(pages);
 
-  free_list_t *freed_block = (free_list_t *)block_vaddr;
-  freed_block->size = block_size;
-
-  free_list_t *current = NULL;
-  // free_list_t *current = get_free_list_head();
-  free_list_t *prev = NULL;
-
-  while (current && (uintptr_t)current < (uintptr_t)freed_block) {
-    prev = current;
-    current = current->next;
-  }
-
-  if (prev && (uintptr_t)prev + prev->size == (uintptr_t)freed_block) {
-    prev->size += freed_block->size;
-    freed_block = prev;
-  } else {
-    if (prev) {
-      prev->next = freed_block;
-    } else {
-
-      // set_free_list_head(freed_block);
-    }
-  }
-
-  if (current &&
-      (uintptr_t)freed_block + freed_block->size == (uintptr_t)current) {
-    freed_block->size += current->size;
-    freed_block->next = current->next;
-  } else {
-    freed_block->next = current;
-  }
-
-  for (size_t i = 1; i < block_size / PAGE_SIZE; i++) {
-    uintptr_t current_vaddr = block_vaddr + i * PAGE_SIZE;
-    void *paddr = vmm_unmap_page((void *)current_vaddr);
-    if (paddr) {
-      buddy_dealloc((uintptr_t)paddr, 0);
-    }
-  }
+  uintptr_t paddr = V2P_WO(vaddr);
+  buddy_dealloc(paddr, order);
 }

--- a/src/memory/kmalloc.c
+++ b/src/memory/kmalloc.c
@@ -1,106 +1,44 @@
 #include "memory/kmalloc.h"
+#include "arch/x86/memlayout.h"
+#include "debug/debug.h"
 #include "drivers/printk.h"
 #include "lib/math.h"
-#include "lib/stdlib.h"
 #include "memory/buddy_allocator/buddy.h"
 #include "memory/consts.h"
-#include "memory/vmm.h"
+#include "memory/memory.h"
 
 #include <stddef.h>
 #include <stdint.h>
 
-static free_list_t *virtual_free_list_head = NULL;
-
 /* Public */
 
-free_list_t *get_free_list_head(void) { return virtual_free_list_head; }
+void kmalloc_init(void) {}
 
-void set_free_list_head(free_list_t *list) { virtual_free_list_head = list; }
-
-void kmalloc_init(void) {
-  uintptr_t heap_start_addr = (uintptr_t)HEAP_START;
-
-  void *first_page_phys = buddy_alloc(0);
-  if (!first_page_phys) {
-    abort("Not enough physical memory to start the heap!");
-  }
-
-  vmm_map_page(first_page_phys, (void *)heap_start_addr, 0);
-
-  size_t max_virtual_size = 0xFFFFFFFF - heap_start_addr;
-  size_t total_physical_memory = buddy_get_total_memory();
-
-  size_t heap_size = max_virtual_size;
-  if (total_physical_memory < heap_size) {
-    heap_size = total_physical_memory;
-  }
-
-  if (heap_size < sizeof(free_list_t)) {
-    abort("Not enough memory to allocate a free_list");
-  }
-
-  virtual_free_list_head = (free_list_t *)heap_start_addr;
-  virtual_free_list_head->size = heap_size;
-  virtual_free_list_head->next = NULL;
-}
-
+/**
+ * @brief Allocates a physically contiguous memory block.
+ *
+ * Fast and suitable for most kernel allocations, especially for hardware/DMA
+ * buffers that require physical contiguity.
+ *
+ * @param size The number of bytes to allocate.
+ * @return A pointer to the allocated memory, or NULL on failure.
+ */
 void *kmalloc(size_t num_bytes) {
-  if (num_bytes == 0 || virtual_free_list_head == NULL) {
+  if (num_bytes == 0 || num_bytes >= MAXIMUM_SLAB_ALLOCATION) {
     return NULL;
   }
 
   size_t total_size = ALIGN(num_bytes + sizeof(block_header_t), PAGE_SIZE);
 
-  free_list_t *current = virtual_free_list_head;
-  free_list_t *prev = NULL;
-  while (current) {
-    if (current->size >= total_size) {
-      break;
-    }
-    prev = current;
-    current = current->next;
-  }
-
-  if (!current) {
-    printk("Not enough mem");
+  uint32_t num_pages = CEIL_DIV(total_size, PAGE_SIZE);
+  uint32_t order = log2(num_pages);
+  void *paddr = buddy_alloc(order);
+  if (!paddr) {
     return NULL;
   }
 
-  uintptr_t virt_addr = (uintptr_t)current;
-  if (current->size - total_size > sizeof(free_list_t)) {
-    free_list_t *new_free_node = (free_list_t *)(virt_addr + total_size);
-
-    void *header_phys_page = buddy_alloc(0);
-    if (!header_phys_page) {
-      abort("Out of physical memory while splitting block!");
-    }
-    vmm_map_page(header_phys_page, (void *)new_free_node, 0);
-
-    new_free_node->size = current->size - total_size;
-    new_free_node->next = current->next;
-
-    if (!prev) {
-      virtual_free_list_head = new_free_node;
-    } else {
-      prev->next = new_free_node;
-    }
-  } else {
-    if (!prev) {
-      virtual_free_list_head = current->next;
-    } else {
-      prev->next = current->next;
-    }
-  }
-
-  for (size_t i = 1; i < total_size / PAGE_SIZE; i++) {
-    void *phys_page = buddy_alloc(0);
-    if (!phys_page) {
-      abort("Out of physical memory during mapping");
-    }
-    vmm_map_page(phys_page, (void *)(virt_addr + i * PAGE_SIZE), 0);
-  }
-
-  block_header_t *header = (block_header_t *)virt_addr;
+  uintptr_t vaddr = P2V_WO((uintptr_t)paddr);
+  block_header_t *header = (block_header_t *)vaddr;
   header->magic = MAGIC;
   header->size = total_size;
 

--- a/src/memory/kmalloc.c
+++ b/src/memory/kmalloc.c
@@ -12,8 +12,6 @@
 
 /* Public */
 
-void kmalloc_init(void) {}
-
 /**
  * @brief Allocates a physically contiguous memory block.
  *
@@ -23,12 +21,12 @@ void kmalloc_init(void) {}
  * @param size The number of bytes to allocate.
  * @return A pointer to the allocated memory, or NULL on failure.
  */
-void *kmalloc(size_t num_bytes) {
-  if (num_bytes == 0 || num_bytes >= MAXIMUM_SLAB_ALLOCATION) {
+void *kmalloc(size_t n) {
+  if (n == 0 || n >= MAXIMUM_SLAB_ALLOCATION) {
     return NULL;
   }
 
-  size_t total_size = ALIGN(num_bytes + sizeof(block_header_t), PAGE_SIZE);
+  size_t total_size = ALIGN(n + sizeof(block_header_t), PAGE_SIZE);
 
   uint32_t num_pages = CEIL_DIV(total_size, PAGE_SIZE);
   uint32_t order = log2(num_pages);
@@ -38,9 +36,13 @@ void *kmalloc(size_t num_bytes) {
   }
 
   uintptr_t vaddr = P2V_WO((uintptr_t)paddr);
+  printk("paddr: 0x%x\n", paddr);
+  printk("vaddr: 0x%x\n", vaddr);
+  BOCHS_MAGICBREAK();
   block_header_t *header = (block_header_t *)vaddr;
   header->magic = MAGIC;
   header->size = total_size;
+  BOCHS_MAGICBREAK();
 
   return (void *)(header + 1);
 }

--- a/src/memory/kmalloc.c
+++ b/src/memory/kmalloc.c
@@ -36,13 +36,9 @@ void *kmalloc(size_t n) {
   }
 
   uintptr_t vaddr = P2V_WO((uintptr_t)paddr);
-  printk("paddr: 0x%x\n", paddr);
-  printk("vaddr: 0x%x\n", vaddr);
-  BOCHS_MAGICBREAK();
   block_header_t *header = (block_header_t *)vaddr;
   header->magic = MAGIC;
   header->size = total_size;
-  BOCHS_MAGICBREAK();
 
   return (void *)(header + 1);
 }

--- a/src/memory/kmalloc.c
+++ b/src/memory/kmalloc.c
@@ -37,6 +37,7 @@ void *kmalloc(size_t n) {
   block_header_t *header = (block_header_t *)vaddr;
   header->magic = MAGIC;
   header->size = total_size;
+  header->flags = MEM_TYPE_KMALLOC;
 
   return (void *)(header + 1);
 }

--- a/src/memory/kmalloc.c
+++ b/src/memory/kmalloc.c
@@ -1,7 +1,5 @@
 #include "memory/kmalloc.h"
 #include "arch/x86/memlayout.h"
-#include "debug/debug.h"
-#include "drivers/printk.h"
 #include "lib/math.h"
 #include "memory/buddy_allocator/buddy.h"
 #include "memory/consts.h"
@@ -29,7 +27,7 @@ void *kmalloc(size_t n) {
   size_t total_size = ALIGN(n + sizeof(block_header_t), PAGE_SIZE);
 
   uint32_t num_pages = CEIL_DIV(total_size, PAGE_SIZE);
-  uint32_t order = log2(num_pages);
+  uint32_t order = log2_rounded_up(num_pages);
   void *paddr = buddy_alloc(order);
   if (!paddr) {
     return NULL;

--- a/src/memory/kmalloc.h
+++ b/src/memory/kmalloc.h
@@ -5,8 +5,6 @@
 
 void kfree(void *ptr);
 
-void *kbrk(void *addr);
-
 void *kmalloc(size_t);
 
 void kmalloc_init(void);

--- a/src/memory/kmalloc.h
+++ b/src/memory/kmalloc.h
@@ -3,6 +3,8 @@
 
 #include <stddef.h>
 
+size_t ksize(void *ptr);
+
 void kfree(void *ptr);
 
 void *kmalloc(size_t);

--- a/src/memory/kmalloc.h
+++ b/src/memory/kmalloc.h
@@ -3,9 +3,6 @@
 
 #include <stddef.h>
 
-#define MAXIMUM_SLAB_ALLOCATION 16384
-#define MAGIC 0xDEADBEEF
-
 void kfree(void *ptr);
 
 void *kbrk(void *addr);

--- a/src/memory/kmalloc.h
+++ b/src/memory/kmalloc.h
@@ -2,22 +2,9 @@
 #define KMALLOC_H
 
 #include <stddef.h>
-#include <stdint.h>
 
-#define HEAP_START (void *)0xD0000000
 #define MAXIMUM_SLAB_ALLOCATION 16384
 #define MAGIC 0xDEADBEEF
-
-typedef struct free_list {
-  size_t size;
-  struct free_list *next;
-} free_list_t;
-
-typedef struct block_header {
-  uint8_t flags; // WIP, ignore for now
-  size_t size;
-  uint32_t magic;
-} block_header_t;
 
 void kfree(void *ptr);
 
@@ -26,9 +13,5 @@ void *kbrk(void *addr);
 void *kmalloc(size_t);
 
 void kmalloc_init(void);
-
-free_list_t *get_free_list_head(void);
-
-void set_free_list_head(free_list_t *);
 
 #endif /* KMALLOC_H */

--- a/src/memory/ksize.c
+++ b/src/memory/ksize.c
@@ -1,6 +1,10 @@
 #include "lib/stdlib.h"
 #include "memory/memory.h"
 
+void kbrk(void) {
+  abort("cannot find a valid break. We are using buddy_allocator");
+}
+
 size_t ksize(void *ptr) {
   if (!ptr) {
     return 0;

--- a/src/memory/ksize.c
+++ b/src/memory/ksize.c
@@ -1,10 +1,6 @@
 #include "lib/stdlib.h"
 #include "memory/memory.h"
 
-void kbrk(void) {
-  abort("cannot find a valid break. We are using buddy_allocator");
-}
-
 size_t ksize(void *ptr) {
   if (!ptr) {
     return 0;

--- a/src/memory/ksize.c
+++ b/src/memory/ksize.c
@@ -1,5 +1,5 @@
 #include "lib/stdlib.h"
-#include "memory/kmalloc.h"
+#include "memory/memory.h"
 
 size_t ksize(void *ptr) {
   if (!ptr) {

--- a/src/memory/memblock.c
+++ b/src/memory/memblock.c
@@ -35,6 +35,7 @@ bool memblock_is_active(void) { return bumpalloc_is_active; }
 void memblock_init(void) {
   next_free_addr = (void *)pmm_get_first_addr();
   heap_end_addr = (void *)(pmm_bitmap_len() * PAGE_SIZE * 8);
+
   bumpalloc_is_active = true;
 }
 

--- a/src/memory/memblock.c
+++ b/src/memory/memblock.c
@@ -10,6 +10,11 @@ static bool bumpalloc_is_active = false;
 static void *next_free_addr = NULL;
 static void *heap_end_addr = NULL;
 
+static void kbrk(size_t heap_size) {
+  next_free_addr = (void *)pmm_get_first_addr();
+  heap_end_addr = (void *)heap_size;
+}
+
 /* Public */
 
 void *get_next_free_addr(void) { return next_free_addr; }
@@ -33,8 +38,7 @@ bool memblock_is_active(void) { return bumpalloc_is_active; }
  * memblock()
  */
 void memblock_init(void) {
-  next_free_addr = (void *)pmm_get_first_addr();
-  heap_end_addr = (void *)(pmm_bitmap_len() * PAGE_SIZE * 8);
+  kbrk(pmm_bitmap_len() * PAGE_SIZE * 8);
 
   bumpalloc_is_active = true;
 }

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -8,13 +8,22 @@
 #define MAXIMUM_SLAB_ALLOCATION 16384
 #define MAGIC 0xDEADBEEF
 
+/* Mask of the Flags variable in block_header struct */
+#define MEM_ALLOCATOR_MASK 0x01
+
+#define MEM_TYPE_KMALLOC 0x00
+#define MEM_TYPE_VMALLOC 0x01
+
 typedef struct free_list {
   size_t size;
   struct free_list *next;
 } free_list_t;
 
 typedef struct block_header {
-  uint8_t flags; // WIP, ignore for now
+  // Bitfield for memory block properties.
+  // Bit 0: Allocator type (0 = kmalloc, 1 = vmalloc)
+  // Bits 1-7: Reserved for future use.
+  uint8_t flags;
   size_t size;
   uint32_t magic;
 } block_header_t;

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -1,0 +1,22 @@
+#ifndef MEMORY_H
+#define MEMORY_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define HEAP_START (void *)0xD0000000
+#define MAXIMUM_SLAB_ALLOCATION 16384
+#define MAGIC 0xDEADBEEF
+
+typedef struct free_list {
+  size_t size;
+  struct free_list *next;
+} free_list_t;
+
+typedef struct block_header {
+  uint8_t flags; // WIP, ignore for now
+  size_t size;
+  uint32_t magic;
+} block_header_t;
+
+#endif /* MEMORY_H */

--- a/src/memory/vfree.c
+++ b/src/memory/vfree.c
@@ -1,0 +1,63 @@
+#include "arch/x86/memlayout.h"
+#include "drivers/printk.h"
+#include "lib/stdlib.h"
+#include "memory/buddy_allocator/buddy.h"
+#include "memory/consts.h"
+#include "memory/vmalloc.h"
+#include "memory/vmm.h"
+
+#include <stdint.h>
+
+void vfree(void *ptr) {
+  if (!ptr) {
+    printk("ptr is null\n");
+    return;
+  }
+
+  block_header_t *header = (block_header_t *)ptr - 1;
+  if (header->magic != MAGIC) {
+    printk("Ptr is corrupt\n");
+    return;
+  }
+
+  uintptr_t block_vaddr = (uintptr_t)header;
+  size_t block_size = header->size;
+
+  free_list_t *freed_block = (free_list_t *)block_vaddr;
+  freed_block->size = block_size;
+
+  free_list_t *current = get_free_list_head();
+  free_list_t *prev = NULL;
+
+  while (current && (uintptr_t)current < (uintptr_t)freed_block) {
+    prev = current;
+    current = current->next;
+  }
+
+  if (prev && (uintptr_t)prev + prev->size == (uintptr_t)freed_block) {
+    prev->size += freed_block->size;
+    freed_block = prev;
+  } else {
+    if (prev) {
+      prev->next = freed_block;
+    } else {
+      set_free_list_head(freed_block);
+    }
+  }
+
+  if (current &&
+      (uintptr_t)freed_block + freed_block->size == (uintptr_t)current) {
+    freed_block->size += current->size;
+    freed_block->next = current->next;
+  } else {
+    freed_block->next = current;
+  }
+
+  for (size_t i = 1; i < block_size / PAGE_SIZE; i++) {
+    uintptr_t current_vaddr = block_vaddr + i * PAGE_SIZE;
+    void *paddr = vmm_unmap_page((void *)current_vaddr);
+    if (paddr) {
+      buddy_dealloc((uintptr_t)paddr, 0);
+    }
+  }
+}

--- a/src/memory/vfree.c
+++ b/src/memory/vfree.c
@@ -21,6 +21,10 @@ void vfree(void *ptr) {
     return;
   }
 
+  if ((header->flags & MEM_ALLOCATOR_MASK) != MEM_TYPE_VMALLOC) {
+    abort("vfree() is used on a kmalloc() pointer\n");
+  }
+
   uintptr_t block_vaddr = (uintptr_t)header;
   size_t block_size = header->size;
 

--- a/src/memory/vfree.c
+++ b/src/memory/vfree.c
@@ -3,6 +3,7 @@
 #include "lib/stdlib.h"
 #include "memory/buddy_allocator/buddy.h"
 #include "memory/consts.h"
+#include "memory/memory.h"
 #include "memory/vmalloc.h"
 #include "memory/vmm.h"
 

--- a/src/memory/vmalloc.c
+++ b/src/memory/vmalloc.c
@@ -1,0 +1,123 @@
+#include "memory/vmalloc.h"
+#include "drivers/printk.h"
+#include "lib/math.h"
+#include "lib/stdlib.h"
+#include "memory/buddy_allocator/buddy.h"
+#include "memory/consts.h"
+#include "memory/vmm.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+static free_list_t *virtual_free_list_head = NULL;
+
+/* Public */
+
+free_list_t *get_free_list_head(void) { return virtual_free_list_head; }
+
+void set_free_list_head(free_list_t *list) { virtual_free_list_head = list; }
+
+void vmalloc_init(void) {
+  uintptr_t heap_start_addr = (uintptr_t)HEAP_START;
+
+  void *first_page_phys = buddy_alloc(0);
+  if (!first_page_phys) {
+    abort("Not enough physical memory to start the heap!");
+  }
+
+  int32_t ret = vmm_map_page(first_page_phys, (void *)heap_start_addr, 0);
+  if (ret < 0) {
+    printk("Should not be possible\n");
+  }
+
+  size_t max_virtual_size = 0xFFFFFFFF - heap_start_addr;
+  size_t total_physical_memory = buddy_get_total_memory();
+
+  size_t heap_size = max_virtual_size;
+  if (total_physical_memory < heap_size) {
+    heap_size = total_physical_memory;
+  }
+
+  if (heap_size < sizeof(free_list_t)) {
+    abort("Not enough memory to allocate a free_list");
+  }
+
+  virtual_free_list_head = (free_list_t *)heap_start_addr;
+  virtual_free_list_head->size = heap_size;
+  virtual_free_list_head->next = NULL;
+}
+
+/**
+ * @brief Allocates a virtually contiguous memory block.
+ *
+ * Slower than kmalloc. Used to allocate large memory regions that do not need
+ * to be physically contiguous, such as for kernel modules.
+ *
+ * @param size The number of bytes to allocate.
+ * @return A pointer to the allocated memory, or NULL on failure.
+ */
+void *vmalloc(size_t num_bytes) {
+  if (num_bytes == 0 || virtual_free_list_head == NULL) {
+    return NULL;
+  }
+
+  size_t total_size = ALIGN(num_bytes + sizeof(block_header_t), PAGE_SIZE);
+
+  free_list_t *current = virtual_free_list_head;
+  free_list_t *prev = NULL;
+  while (current) {
+    if (current->size >= total_size) {
+      break;
+    }
+    prev = current;
+    current = current->next;
+  }
+
+  if (!current) {
+    printk("Not enough mem");
+    return NULL;
+  }
+
+  uintptr_t virt_addr = (uintptr_t)current;
+  if (current->size - total_size > sizeof(free_list_t)) {
+    free_list_t *new_free_node = (free_list_t *)(virt_addr + total_size);
+
+    void *header_phys_page = buddy_alloc(0);
+    if (!header_phys_page) {
+      abort("Out of physical memory while splitting block!");
+    }
+    int32_t ret = vmm_map_page(header_phys_page, (void *)new_free_node, 0);
+    if (ret < 0) {
+      printk("Page already exists\n");
+    }
+
+    new_free_node->size = current->size - total_size;
+    new_free_node->next = current->next;
+
+    if (!prev) {
+      virtual_free_list_head = new_free_node;
+    } else {
+      prev->next = new_free_node;
+    }
+  } else {
+    if (!prev) {
+      virtual_free_list_head = current->next;
+    } else {
+      prev->next = current->next;
+    }
+  }
+
+  for (size_t i = 0; i < total_size / PAGE_SIZE; i += 1) {
+    void *phys_page = buddy_alloc(0);
+    if (!phys_page) {
+      abort("Out of physical memory during mapping");
+    }
+    vmm_map_page(phys_page, (void *)(virt_addr + i * PAGE_SIZE), 0);
+  }
+
+  block_header_t *header = (block_header_t *)virt_addr;
+  header->magic = MAGIC;
+  header->size = total_size;
+
+  return (void *)(header + 1);
+}

--- a/src/memory/vmalloc.h
+++ b/src/memory/vmalloc.h
@@ -1,0 +1,33 @@
+#ifndef VMALLOC_H
+#define VMALLOC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define HEAP_START (void *)0xD0000000
+#define MAGIC 0xDEADBEEF
+
+typedef struct free_list {
+  size_t size;
+  struct free_list *next;
+} free_list_t;
+
+typedef struct block_header {
+  uint8_t flags; // WIP, ignore for now
+  size_t size;
+  uint32_t magic;
+} block_header_t;
+
+void vfree(void *ptr);
+
+void *vbrk(void *addr);
+
+void *vmalloc(size_t);
+
+void vmalloc_init(void);
+
+free_list_t *get_free_list_head(void);
+
+void set_free_list_head(free_list_t *);
+
+#endif /* VMALLOC_H */

--- a/src/memory/vmalloc.h
+++ b/src/memory/vmalloc.h
@@ -1,22 +1,8 @@
 #ifndef VMALLOC_H
 #define VMALLOC_H
 
+#include "memory/memory.h"
 #include <stddef.h>
-#include <stdint.h>
-
-#define HEAP_START (void *)0xD0000000
-#define MAGIC 0xDEADBEEF
-
-typedef struct free_list {
-  size_t size;
-  struct free_list *next;
-} free_list_t;
-
-typedef struct block_header {
-  uint8_t flags; // WIP, ignore for now
-  size_t size;
-  uint32_t magic;
-} block_header_t;
 
 void vfree(void *ptr);
 

--- a/src/memory/vmalloc.h
+++ b/src/memory/vmalloc.h
@@ -6,8 +6,6 @@
 
 void vfree(void *ptr);
 
-void *vbrk(void *addr);
-
 void *vmalloc(size_t);
 
 void vmalloc_init(void);

--- a/src/memory/vmalloc.h
+++ b/src/memory/vmalloc.h
@@ -4,6 +4,8 @@
 #include "memory/memory.h"
 #include <stddef.h>
 
+size_t vsize(void *ptr);
+
 void vfree(void *ptr);
 
 void *vmalloc(size_t);

--- a/src/memory/vmm.c
+++ b/src/memory/vmm.c
@@ -143,7 +143,7 @@ void vmm_init_pages(void) {
   memset(page_directory, 0, sizeof(uint32_t) * 1024);
 
   size_t memory_to_map = ZONE_NORMAL;
-  size_t total_ram = (pmm_bitmap_len() * PAGE_SIZE * 8) - pmm_get_first_addr();
+  size_t total_ram = (pmm_bitmap_len() * PAGE_SIZE * 8);
   if (ZONE_NORMAL > total_ram) {
     memory_to_map = total_ram;
   }
@@ -195,5 +195,5 @@ void vmm_init_pages(void) {
     abort("Scratch Page is already taken\n");
   }
 
-  visualize_paging(32, 32);
+  visualize_paging(8, 8);
 }

--- a/src/memory/vmm.h
+++ b/src/memory/vmm.h
@@ -7,6 +7,8 @@
 #define PAGE_FLAG_WRITABLE (1 << 1)
 #define PAGE_FLAG_SUPERVISOR (1 << 2)
 
+#define ZONE_NORMAL 896 * 1024 * 1024
+
 void *vmm_find_free_region(uint32_t);
 
 void vmm_init_pages(void);

--- a/src/memory/vmm.h
+++ b/src/memory/vmm.h
@@ -9,9 +9,9 @@
 
 void *vmm_find_free_region(uint32_t);
 
-void vmm_map_page(void *physaddr, void *virtualaddr, uint32_t flags);
-
 void vmm_init_pages(void);
+
+int32_t vmm_map_page(void *physaddr, void *virtualaddr, uint32_t flags);
 
 void *vmm_unmap_page(void *);
 

--- a/src/memory/vsize.c
+++ b/src/memory/vsize.c
@@ -1,5 +1,5 @@
 #include "lib/stdlib.h"
-#include "memory/kmalloc.h"
+#include "memory/memory.h"
 
 size_t vsize(void *ptr) {
   if (!ptr) {

--- a/src/memory/vsize.c
+++ b/src/memory/vsize.c
@@ -1,6 +1,10 @@
 #include "lib/stdlib.h"
 #include "memory/memory.h"
 
+void vbrk(void) {
+  abort("cannot find a valid break. We are using buddy_allocator");
+}
+
 size_t vsize(void *ptr) {
   if (!ptr) {
     return 0;

--- a/src/memory/vsize.c
+++ b/src/memory/vsize.c
@@ -1,10 +1,6 @@
 #include "lib/stdlib.h"
 #include "memory/memory.h"
 
-void vbrk(void) {
-  abort("cannot find a valid break. We are using buddy_allocator");
-}
-
 size_t vsize(void *ptr) {
   if (!ptr) {
     return 0;

--- a/src/memory/vsize.c
+++ b/src/memory/vsize.c
@@ -1,0 +1,16 @@
+#include "lib/stdlib.h"
+#include "memory/kmalloc.h"
+
+size_t vsize(void *ptr) {
+  if (!ptr) {
+    return 0;
+  }
+
+  block_header_t *header_ptr = (block_header_t *)ptr - 1;
+
+  if (header_ptr->magic != MAGIC) {
+    abort("Corrupt pointer provided to ksize");
+  }
+
+  return header_ptr->size;
+}


### PR DESCRIPTION
This PR refactors the kernel's memory management by splitting the allocator into `kmalloc` (physically contiguous) and `vmalloc` (virtually contiguous). This change establishes a clearer, more robust, and standard memory allocation API.

## Key Changes

* **`kmalloc`**: Now a lightweight wrapper around the buddy allocator for fast, **physically contiguous** allocations suitable for DMA.
* **`vmalloc`**: New allocator for **virtually contiguous** memory, ideal for large data structures where physical contiguity isn't required.
* **Buddy Allocator**: The initialization logic has been rewritten to correctly handle memory regions that are not a power of two.
* **VMM**: The initial page setup now creates a standard higher-half kernel memory layout with an identity-mapped region.
* **Modernization**: Centralized memory definitions into `memory/memory.h` and updated the project to the C17 standard.