### PR TITLE
Implement PIT-based timer interrupts and refactor IRQ handling

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -5,6 +5,7 @@ If:
   PathMatch:
     - 'src/arch/x86/idt/exceptions.c'
     - 'src/arch/x86/idt/syscalls.c'
+    - 'src/arch/x86/idt/irq.c'
 
 Diagnostics:
   Suppress:

--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,8 @@
+target remote :1234
+add-symbol-file "ferrite-c.elf" 0x100000
+
+set disassembly-flavor intel
+set architecture i386
+
+layout src
+b kmain

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NAME = ferrite-c.elf
 SDIR = ./src
 ODIR = ./build
 
-CFLAGS = -I$(SDIR) -m32 -ffreestanding -g -O2 -Wall -Wextra -Werror \
+CFLAGS = -I$(SDIR) -m32 -ffreestanding -ggdb3 -O2 -Wall -Wextra -Werror \
          -fno-stack-protector -D__is_libk -D__print_serial -D__bochs -pedantic -std=c17 -march=i386
 ASFLAGS = -felf32
 LDFLAGS = -T $(SDIR)/arch/x86/x86.ld -ffreestanding -nostdlib -lgcc -march=i386
@@ -18,7 +18,7 @@ ASM_SOURCES = $(shell find $(SDIR) -type f -name '*.asm')
 C_OBJECTS = $(patsubst $(SDIR)/%.c,$(ODIR)/%.o,$(C_SOURCES))
 ASM_OBJECTS = $(patsubst $(SDIR)/%.asm,$(ODIR)/%.o,$(ASM_SOURCES))
 
-QEMUFLAGS = -serial stdio -m 8
+QEMUFLAGS = -serial stdio -m 16 -cpu 486
 
 all: $(NAME)
 

--- a/src/arch/x86/boot.asm
+++ b/src/arch/x86/boot.asm
@@ -63,9 +63,6 @@ _start:
 	or  ecx, 0x80000000
 	mov cr0, ecx
 
-	jmp higher_half
-
-higher_half:
 	mov esp, stack_top
 
 	;    Add magic number and mutliboot header into stack

--- a/src/arch/x86/idt/exceptions.c
+++ b/src/arch/x86/idt/exceptions.c
@@ -1,11 +1,6 @@
 #include "arch/x86/idt/idt.h"
-#include "arch/x86/io.h"
-#include "arch/x86/pic.h"
-#include "arch/x86/time/rtc.h"
 #include "debug/debug.h"
 #include "debug/panic.h"
-#include "drivers/keyboard.h"
-#include "sys/tasks.h"
 
 #include <stdint.h>
 
@@ -24,7 +19,7 @@ divide_by_zero_handler(registers_t *regs) {
 __attribute__((target("general-regs-only"), interrupt)) void
 debug_interrupt_handler(registers_t *regs) {
   (void)regs;
-  BOCHS_BREAK();
+  BOCHS_MAGICBREAK();
 }
 
 __attribute__((target("general-regs-only"), interrupt)) void
@@ -35,7 +30,7 @@ non_maskable_interrupt_handler(registers_t *regs) {
 __attribute__((target("general-regs-only"), interrupt)) void
 breakpoint_handler(registers_t *regs) {
   (void)regs;
-  BOCHS_BREAK();
+  BOCHS_MAGICBREAK();
 }
 
 __attribute__((target("general-regs-only"), interrupt)) void
@@ -142,27 +137,4 @@ page_fault(registers_t *regs, uint32_t error_code) {
    * address is being mapped with a virtual address.
    */
   __asm__ volatile("cli; hlt");
-}
-
-/* Hardware Interrupts */
-
-__attribute__((target("general-regs-only"), interrupt)) void
-keyboard_handler(registers_t *regs) {
-  (void)regs;
-
-  int32_t scancode = inb(KEYBOARD_DATA_PORT);
-  setscancode(scancode);
-
-  schedule_task(keyboard_input);
-
-  pic_send_eoi(1);
-}
-
-__attribute__((target("general-regs-only"), interrupt)) void
-rtc_handler(registers_t *regs) {
-  (void)regs;
-
-  schedule_task(rtc_task);
-
-  pic_send_eoi(8);
 }

--- a/src/arch/x86/idt/idt.c
+++ b/src/arch/x86/idt/idt.c
@@ -3,12 +3,15 @@
 
 #include <stdint.h>
 
+#define NUM_EXCEPTION_HANDLERS 17
+#define NUM_HARDWARE_HANDLERS 3
+
 extern void syscall_handler(registers_t *);
 
 interrupt_descriptor_t idt_entries[IDT_ENTRY_COUNT];
 descriptor_pointer_t idt_ptr;
 
-const interrupt_handler_entry_t EXCEPTION_HANDLERS[17] = {
+const interrupt_handler_entry_t EXCEPTION_HANDLERS[NUM_EXCEPTION_HANDLERS] = {
     {REGULAR, .handler.regular = divide_by_zero_handler},
     {REGULAR, .handler.regular = debug_interrupt_handler},
     {REGULAR, .handler.regular = non_maskable_interrupt_handler},
@@ -27,8 +30,8 @@ const interrupt_handler_entry_t EXCEPTION_HANDLERS[17] = {
     {REGULAR, .handler.regular = reserved_by_cpu},
     {REGULAR, .handler.regular = x87_fpu_exception},
 };
-const interrupt_hardware_t HARDWARE_HANDLERS[2] = {{0x21, keyboard_handler},
-                                                   {0x28, rtc_handler}};
+const interrupt_hardware_t HARDWARE_HANDLERS[NUM_HARDWARE_HANDLERS] = {
+    {0x20, timer_handler}, {0x21, keyboard_handler}, {0x27, spurious_handler}};
 
 static void idt_set_gate(uint32_t num, uint32_t handler) {
   idt_entries[num].pointer_low = (handler & 0xffff);
@@ -40,7 +43,7 @@ static void idt_set_gate(uint32_t num, uint32_t handler) {
 
 void idt_init(void) {
   // Exceptions
-  for (int32_t i = 0; i < 17; i += 1) {
+  for (int32_t i = 0; i < NUM_EXCEPTION_HANDLERS; i += 1) {
     uint32_t handler = 0;
 
     if (EXCEPTION_HANDLERS[i].type == REGULAR) {
@@ -53,7 +56,7 @@ void idt_init(void) {
   }
 
   // Hardware Interrupts
-  for (int32_t i = 0; i < 2; i += 1) {
+  for (int32_t i = 0; i < NUM_HARDWARE_HANDLERS; i += 1) {
     idt_set_gate(HARDWARE_HANDLERS[i].hex, (uint32_t)HARDWARE_HANDLERS[i].func);
   }
 

--- a/src/arch/x86/idt/idt.h
+++ b/src/arch/x86/idt/idt.h
@@ -64,8 +64,9 @@ void general_protection_fault(registers_t *, uint32_t error_code);
 void page_fault(registers_t *, uint32_t error_code);
 
 // --- Hardware Interrupts ---
+void timer_handler(registers_t *);
 void keyboard_handler(registers_t *);
-void rtc_handler(registers_t *);
+void spurious_handler(registers_t *);
 
 void idt_init(void);
 

--- a/src/arch/x86/idt/irq.c
+++ b/src/arch/x86/idt/irq.c
@@ -1,0 +1,52 @@
+#include "arch/x86/io.h"
+#include "arch/x86/pic.h"
+#include "arch/x86/pit.h"
+#include "arch/x86/time/time.h"
+#include "drivers/keyboard.h"
+#include "sys/tasks.h"
+
+#include <stdint.h>
+
+volatile uint64_t ticks = 0;
+
+__attribute__((target("general-regs-only"), interrupt)) void
+timer_handler(registers_t *regs) {
+  (void)regs;
+
+  ticks += 1;
+  if (ticks % HZ == 0) {
+    time_t new_epoch = getepoch() + 1;
+    setepoch(new_epoch);
+  }
+
+  pic_send_eoi(0);
+}
+
+__attribute__((target("general-regs-only"), interrupt)) void
+keyboard_handler(registers_t *regs) {
+  (void)regs;
+
+  int32_t scancode = inb(KEYBOARD_DATA_PORT);
+  setscancode(scancode);
+
+  schedule_task(keyboard_input);
+
+  pic_send_eoi(1);
+}
+
+#include "drivers/printk.h"
+
+__attribute__((target("general-regs-only"), interrupt)) void
+spurious_handler(registers_t *regs) {
+  (void)regs;
+
+  uint8_t isr = pic_get_isr();
+
+  if (!(isr & 0x80)) {
+    printk("Spurious IRQ 7 on Master PIC handled. No EOI sent.\n");
+    return;
+  }
+
+  printk("Real IRQ 7 received. Sending EOI.\n");
+  pic_send_eoi(0);
+}

--- a/src/arch/x86/pic.c
+++ b/src/arch/x86/pic.c
@@ -1,6 +1,18 @@
 #include "arch/x86/pic.h"
 #include "arch/x86/io.h"
 
+#define PIC_READ_ISR 0x0b /* OCW3 irq service next CMD read */
+
+static uint16_t __pic_get_irq_reg(int ocw3) {
+  /* OCW3 to PIC CMD to get the register values.  PIC2 is chained, and
+   * represents IRQs 8-15.  PIC1 is IRQs 0-7, with 2 being the chain */
+  outb(PIC1_COMMAND, ocw3);
+  outb(PIC2_COMMAND, ocw3);
+  return (inb(PIC2_COMMAND) << 8) | inb(PIC1_COMMAND);
+}
+
+uint16_t pic_get_isr(void) { return __pic_get_irq_reg(PIC_READ_ISR); }
+
 void pic_remap(int32_t offset1, int32_t offset2) {
   // starts the initialization sequence (in cascade mode)
   outb(PIC1_COMMAND, ICW1_INIT | ICW1_ICW4);
@@ -28,6 +40,6 @@ void pic_remap(int32_t offset1, int32_t offset2) {
   io_wait();
 
   // Unmask both PICs.
-  outb(PIC2_DATA, 0xFE);
-  outb(PIC1_DATA, 0xF9);
+  outb(PIC1_DATA, 0xF8); // 0b1111 1000
+  outb(PIC2_DATA, 0xFF);
 }

--- a/src/arch/x86/pic.h
+++ b/src/arch/x86/pic.h
@@ -2,6 +2,7 @@
 #define PIC_H
 
 #include "arch/x86/io.h"
+
 #include <stdint.h>
 
 #define PIC1 0x20 /* IO base address for master PIC */
@@ -23,12 +24,11 @@
 #define ICW4_BUF_MASTER 0x0C /* Buffered mode/master */
 #define ICW4_SFNM 0x10       /* Special fully nested (not) */
 
-#ifndef EOI_H
-#define EOI_H
+#define PIC_EOI 0x20 /* End-of-interrupt command code */
 
 void pic_remap(int32_t, int32_t);
 
-#define PIC_EOI 0x20 /* End-of-interrupt command code */
+uint16_t pic_get_isr(void);
 
 static inline void pic_send_eoi(uint8_t irq) {
   if (irq & 8) {
@@ -37,7 +37,5 @@ static inline void pic_send_eoi(uint8_t irq) {
 
   outb(PIC1_COMMAND, PIC_EOI);
 }
-
-#endif /* EOI_H */
 
 #endif /* PIC_H */

--- a/src/arch/x86/pit.h
+++ b/src/arch/x86/pit.h
@@ -1,0 +1,34 @@
+#ifndef PIT_H
+#define PIT_H
+
+#include "arch/x86/io.h"
+
+#include <stdint.h>
+
+#ifndef HZ
+#define HZ 100
+#endif
+
+#define SHIFT_HZ 7
+#define SHIFT_SCALE 24 /* shift for phase scale factor */
+
+#define CLOCK_TICK_RATE 1193180 /* Underlying HZ */
+#define CLOCK_TICK_FACTOR 20    /* Factor of both 1000000 and CLOCK_TICK_RATE */
+#define LATCH ((CLOCK_TICK_RATE + HZ / 2) / HZ)
+
+#define FINETUNE                                                               \
+  (((((LATCH * HZ - CLOCK_TICK_RATE) << SHIFT_HZ) *                            \
+     (1000000 / CLOCK_TICK_FACTOR) / (CLOCK_TICK_RATE / CLOCK_TICK_FACTOR))    \
+    << (SHIFT_SCALE - SHIFT_HZ)) /                                             \
+   HZ)
+
+static inline void set_pit_count(const uint32_t count) {
+  __asm__ __volatile__("cli");
+
+  outb(0x40, count & 0xFF);
+  outb(0x40, (count & 0xFF00) >> 8);
+
+  __asm__ __volatile__("sti");
+}
+
+#endif /* PIT_H */

--- a/src/arch/x86/time/rtc.c
+++ b/src/arch/x86/time/rtc.c
@@ -1,5 +1,4 @@
 #include "rtc.h"
-#include "arch/x86/idt/idt.h"
 #include "arch/x86/io.h"
 #include "arch/x86/time/time.h"
 #include "drivers/printk.h"
@@ -7,26 +6,17 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define REG_A 0x8A
-#define REG_B 0x8B
-
-uint8_t rate = 14;
-uint32_t frequency = 0;
-volatile uint64_t ticks = 0;
+#define RTC_REG_A 0x0A
+#define RTC_REG_B 0x0B
+#define BCD_TO_BIN(n) ((n >> 4) * 10) + (n & 0x0F);
 
 static inline uint8_t read_rtc_register(int32_t reg) {
   outb(0x70, reg);
   return inb(0x71);
 }
 
-static inline uint8_t bcd_to_bin(uint8_t bcd) {
-  return ((bcd >> 4) * 10) + (bcd & 0x0F);
-}
-
-inline uint32_t getfrequency(void) { return frequency; }
-
 static void rtc_read_time(rtc_time_t *time) {
-  while (read_rtc_register(0x0A) & 0x80)
+  while (read_rtc_register(RTC_REG_A) & 0x80)
     ;
 
   time->second = read_rtc_register(0x00);
@@ -36,52 +26,28 @@ static void rtc_read_time(rtc_time_t *time) {
   time->year = read_rtc_register(0x09);
   time->day = read_rtc_register(0x07);
 
-  if (!(read_rtc_register(0x0B) & 0x04)) {
-    time->second = bcd_to_bin(time->second);
-    time->minute = bcd_to_bin(time->minute);
-    time->hour = bcd_to_bin(time->hour);
-    time->month = bcd_to_bin(time->month);
-    time->year = bcd_to_bin(time->year);
-    time->day = bcd_to_bin(time->day);
+  if (!(read_rtc_register(RTC_REG_B) & 0x04)) {
+    time->second = BCD_TO_BIN(time->second);
+    time->minute = BCD_TO_BIN(time->minute);
+    time->hour = BCD_TO_BIN(time->hour);
+    time->month = BCD_TO_BIN(time->month);
+    time->year = BCD_TO_BIN(time->year);
+    time->day = BCD_TO_BIN(time->day);
   }
 }
 
 void rtc_init(void) {
   rtc_time_t time;
-  frequency = 32768 >> (rate - 1);
 
-  outb(0x70, REG_A);                  // Select Register A, disable NMI
-  char prev_a = inb(0x71);            // Read current value of Register A
-  outb(0x70, REG_A);                  // Re-select Register A
-  outb(0x71, (prev_a & 0xF0) | rate); // Write new rate to Register A
+  outb(0x70, 0x8B);           // Select Register B, disable NMI
+  uint8_t prev_b = inb(0x71); // Read current value of Register B
+  outb(0x70, 0x8B);           // Re-select Register B
+  outb(0x71, prev_b & ~0x40); // Write back with bit 6 (PIE) cleared
 
-  outb(0x70, REG_B);         // Select Register B, disable NMI
-  char prev_b = inb(0x71);   // Read current value of Register B
-  outb(0x70, REG_B);         // Re-select Register B
-  outb(0x71, prev_b | 0x40); // Enable bit 6 (Periodic Interrupt)
-
-  rtc_read_time(&time);
-
+  (void)rtc_read_time(&time);
   printk("RTC Time: 20%d-%d-%d %d:%d:%d\n", time.year, time.month, time.day,
          time.hour, time.minute, time.second);
 
   time_t epoch = to_epoch(&time);
   setepoch(epoch);
-}
-
-void rtc_task(registers_t *regs) {
-  (void)regs;
-
-  outb(0x70, 0x0C); // select register C
-  inb(0x71);        // just throw away contents
-
-  ticks += 1;
-  int32_t frequency = getfrequency();
-  uint64_t seconds_since_epoch = getepoch();
-
-  if (ticks % frequency == 0) {
-    seconds_since_epoch += 1;
-
-    setepoch(seconds_since_epoch);
-  }
 }

--- a/src/arch/x86/time/rtc.h
+++ b/src/arch/x86/time/rtc.h
@@ -1,7 +1,5 @@
-#ifndef _RTC_H_
-#define _RTC_H_
-
-#include "arch/x86/idt/idt.h"
+#ifndef RTC_H
+#define RTC_H
 
 #include <stdint.h>
 
@@ -14,10 +12,6 @@ typedef struct {
   uint8_t year;
 } rtc_time_t;
 
-uint32_t getfrequency(void);
-
 void rtc_init(void);
 
-void rtc_task(registers_t *);
-
-#endif
+#endif /* RTC_H */

--- a/src/arch/x86/time/time.c
+++ b/src/arch/x86/time/time.c
@@ -12,7 +12,7 @@ __attribute__((warn_unused_result)) inline time_t getepoch(void) {
   return seconds_since_epoch;
 }
 
-void setepoch(time_t new) { seconds_since_epoch = new; }
+inline void setepoch(time_t new) { seconds_since_epoch = new; }
 
 static inline int32_t is_leap(uint32_t year) {
   return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);

--- a/src/arch/x86/x86.ld
+++ b/src/arch/x86/x86.ld
@@ -11,6 +11,8 @@
 * protection and efficient virtual memory management.
 */
 
+OUTPUT_FORMAT("elf32-i386", "elf32-i386", "elf32-i386")
+OUTPUT_ARCH(i386)
 ENTRY(_start)
 
 SECTIONS {

--- a/src/debug/debug.h
+++ b/src/debug/debug.h
@@ -5,9 +5,6 @@
 
 #include "arch/x86/io.h"
 
-#define BOCHS_BREAK()                                                          \
-  outw(0x8A00, 0x8A00);                                                        \
-  outw(0x8A00, 0x08AE0);
 #define BOCHS_MAGICBREAK() __asm__ __volatile__("xchg %bx, %bx");
 
 static inline void bochs_print_string(const char *str) {

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,5 +1,6 @@
 #include "arch/x86/gdt/gdt.h"
 #include "arch/x86/pic.h"
+#include "arch/x86/pit.h"
 #include "arch/x86/time/rtc.h"
 #include "debug/debug.h"
 #include "drivers/console.h"
@@ -31,6 +32,7 @@ __attribute__((noreturn)) void kmain(uint32_t magic, multiboot_info_t *mbd) {
   gdt_init();
   idt_init();
   pic_remap(0x20, 0x28);
+  set_pit_count(LATCH);
 
   vga_init();
   rtc_init();

--- a/src/memory/pmm.c
+++ b/src/memory/pmm.c
@@ -96,12 +96,12 @@ void *pmm_get_physaddr(void *vaddr) {
   uint32_t offset = (uint32_t)vaddr & 0xFFF;
   uint32_t *pd = (uint32_t *)0xFFFFF000;
 
-  if (!(pd[pdindex] & PAGE_FLAG_PRESENT)) {
+  if (!(pd[pdindex] & PTE_P)) {
     return 0;
   }
 
   uint32_t *pt = (uint32_t *)(0xFFC00000 + (pdindex * PAGE_SIZE));
-  if (!(pt[ptindex] & PAGE_FLAG_PRESENT)) {
+  if (!(pt[ptindex] & PTE_P)) {
     return 0;
   }
 

--- a/src/memory/vmalloc.c
+++ b/src/memory/vmalloc.c
@@ -12,12 +12,6 @@
 
 static free_list_t *virtual_free_list_head = NULL;
 
-static void vbrk(size_t heap_size) {
-  virtual_free_list_head = (free_list_t *)HEAP_START;
-  virtual_free_list_head->size = heap_size;
-  virtual_free_list_head->next = NULL;
-}
-
 /* Public */
 
 free_list_t *get_free_list_head(void) { return virtual_free_list_head; }
@@ -49,7 +43,9 @@ void vmalloc_init(void) {
     abort("Not enough memory to allocate a free_list");
   }
 
-  vbrk(heap_size);
+  virtual_free_list_head = (free_list_t *)HEAP_START;
+  virtual_free_list_head->size = heap_size;
+  virtual_free_list_head->next = NULL;
 }
 
 /**

--- a/src/memory/vmm.c
+++ b/src/memory/vmm.c
@@ -1,6 +1,5 @@
 #include "memory/vmm.h"
 #include "arch/x86/memlayout.h"
-#include "debug/debug.h"
 #include "drivers/printk.h"
 #include "lib/stdlib.h"
 #include "memory/buddy_allocator/buddy.h"
@@ -32,14 +31,14 @@ void visualize_paging(uint32_t limit_mb, uint32_t detailed_mb) {
   for (uint32_t pd_index = 0; pd_index < pd_limit; ++pd_index) {
     uintptr_t base_vaddr = pd_index * 0x400000; // 4 MB chunks
 
-    if (page_directory[pd_index] & PAGE_FLAG_PRESENT) {
+    if (page_directory[pd_index] & PTE_P) {
       printk("VAddr 0x%x - 0x%x: [", base_vaddr, base_vaddr + 0x3FFFFF);
 
       if ((pd_index * 4) < detailed_mb) {
         uint32_t *page_table = &((uintptr_t *)0xFFC00000)[pd_index * 1024];
 
         for (int pt_index = 0; pt_index < 1024; ++pt_index) {
-          if (page_table[pt_index] & PAGE_FLAG_PRESENT) {
+          if (page_table[pt_index] & PTE_P) {
             printk(".");
           } else {
             printk(" ");
@@ -70,7 +69,7 @@ void *vmm_unmap_page(void *vaddr) {
   uint32_t *pt = (uint32_t *)(0xFFC00000 + (pdindex * PAGE_SIZE));
   uint32_t *pte = &pt[ptindex];
 
-  if (!(*pte & PAGE_FLAG_PRESENT)) {
+  if (!(*pte & PTE_P)) {
     return NULL;
   }
 
@@ -99,7 +98,7 @@ __attribute__((warn_unused_result)) int32_t vmm_map_page(void *physaddr,
   uint32_t *pd = (uint32_t *)0xFFFFF000;
   uint32_t *pt = (uint32_t *)(0xFFC00000 + (pdindex * PAGE_SIZE));
 
-  if (!(pd[pdindex] & PAGE_FLAG_PRESENT)) {
+  if (!(pd[pdindex] & PTE_P)) {
     uintptr_t paddr = 0;
     if (memblock_is_active() == true) {
       paddr = (uintptr_t)memblock(PAGE_SIZE);
@@ -111,19 +110,18 @@ __attribute__((warn_unused_result)) int32_t vmm_map_page(void *physaddr,
       abort("Out of physical memory");
     }
 
-    pd[pdindex] =
-        paddr | PAGE_FLAG_SUPERVISOR | PAGE_FLAG_WRITABLE | PAGE_FLAG_PRESENT;
+    pd[pdindex] = paddr | PTE_U | PTE_W | PTE_P;
     flush_tlb();
 
     memset(pt, 0, PAGE_SIZE);
   }
 
-  if (pt[ptindex] & PAGE_FLAG_PRESENT) {
+  if (pt[ptindex] & PTE_P) {
     printk("Mapping already exists\n");
     return -1;
   }
 
-  pt[ptindex] = ((uint32_t)physaddr) | (flags & 0xFFF) | PAGE_FLAG_PRESENT;
+  pt[ptindex] = ((uint32_t)physaddr) | (flags & 0xFFF) | PTE_P;
 
   flush_tlb();
   return 0;
@@ -134,7 +132,7 @@ void vmm_remap_page(void *vaddr, void *paddr, int32_t flags) {
   uint32_t ptindex = (uint32_t)vaddr >> 12 & 0x03FF;
 
   uint32_t *pt = (uint32_t *)(0xFFC00000 + (pdindex * PAGE_SIZE));
-  pt[ptindex] = ((uint32_t)paddr) | (flags & 0xFFF) | PAGE_FLAG_PRESENT;
+  pt[ptindex] = ((uint32_t)paddr) | (flags & 0xFFF) | PTE_P;
 
   flush_tlb();
 }
@@ -158,8 +156,7 @@ void vmm_init_pages(void) {
     for (int i = 0; i < 1024; i++) {
       uint32_t page_phys_addr = paddr + (i * PAGE_SIZE);
       if (page_phys_addr < memory_to_map) {
-        pt_vaddr[i] = page_phys_addr | PAGE_FLAG_PRESENT | PAGE_FLAG_WRITABLE |
-                      PAGE_FLAG_SUPERVISOR;
+        pt_vaddr[i] = page_phys_addr | PTE_P | PTE_W | PTE_U;
         continue;
       }
 
@@ -167,18 +164,16 @@ void vmm_init_pages(void) {
     }
 
     uint32_t pd_index = (KERNBASE + paddr) / 0x400000;
-    page_directory[pd_index] = (uintptr_t)pt_paddr | PAGE_FLAG_PRESENT |
-                               PAGE_FLAG_WRITABLE | PAGE_FLAG_SUPERVISOR;
+    page_directory[pd_index] = (uintptr_t)pt_paddr | PTE_P | PTE_W | PTE_U;
 
     uint32_t identity_pd_index = paddr / 0x400000;
-    page_directory[identity_pd_index] = (uintptr_t)pt_paddr |
-                                        PAGE_FLAG_PRESENT | PAGE_FLAG_WRITABLE |
-                                        PAGE_FLAG_SUPERVISOR;
+    page_directory[identity_pd_index] =
+        (uintptr_t)pt_paddr | PTE_P | PTE_W | PTE_U;
   }
 
   uint32_t page_directory_paddr = V2P_WO((uint32_t)page_directory);
-  page_directory[1023] = (uintptr_t)page_directory_paddr | PAGE_FLAG_PRESENT |
-                         PAGE_FLAG_WRITABLE | PAGE_FLAG_SUPERVISOR;
+  page_directory[1023] =
+      (uintptr_t)page_directory_paddr | PTE_P | PTE_W | PTE_U;
 
   load_page_directory((uint32_t *)page_directory_paddr);
   enable_paging();
@@ -189,8 +184,7 @@ void vmm_init_pages(void) {
     abort("Something went wrong");
   }
 
-  int32_t ret = vmm_map_page(paddr, SCRATCH_VADDR,
-                             PAGE_FLAG_WRITABLE | PAGE_FLAG_SUPERVISOR);
+  int32_t ret = vmm_map_page(paddr, SCRATCH_VADDR, PTE_W | PTE_U);
   if (ret < 0) {
     abort("Scratch Page is already taken\n");
   }

--- a/src/memory/vmm.h
+++ b/src/memory/vmm.h
@@ -3,9 +3,9 @@
 
 #include <stdint.h>
 
-#define PAGE_FLAG_PRESENT (1 << 0)
-#define PAGE_FLAG_WRITABLE (1 << 1)
-#define PAGE_FLAG_SUPERVISOR (1 << 2)
+#define PTE_P (1 << 0)
+#define PTE_W (1 << 1)
+#define PTE_U (1 << 2)
 
 #define ZONE_NORMAL 896 * 1024 * 1024
 


### PR DESCRIPTION
### Summary
Implements proper timer interrupts using the Programmable Interval Timer (PIT) at 100Hz and refactors IRQ handling for better code organization.

### Key Changes

- **PIT Timer Implementation**
  - Added 100Hz timer interrupt (IRQ0) to replace RTC-based timing
  - System epoch now updates via PIT ticks instead of RTC interrupts
  - Added `pit.h` with timer configuration macros

- **IRQ Refactoring**
  - Moved hardware interrupt handlers to new `irq.c` file
  - Added spurious IRQ7 detection and handling
  - Enhanced PIC with `pic_get_isr()` for reading In-Service Register

- **Code Cleanup**
  - Renamed page flags: `PAGE_FLAG_*` → `PTE_*` (e.g., `PAGE_FLAG_PRESENT` → `PTE_P`)
  - Simplified debug macros to use only `BOCHS_MAGICBREAK()`
  - Added `.gdbinit` for easier debugging

### Technical Notes
- Timer frequency: 100Hz (10ms per tick)
- PIC IRQ mask: 0xF8 (unmasks IRQ 0, 1, 2)
- Build: Added `-ggdb3` flag and set CPU to 486

### Breaking Changes
- RTC periodic interrupts no longer used for timekeeping
- `BOCHS_BREAK()` macro removed