### PR TITLE
Implement sys_close and cleanup file operations

### DIFF
--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -9,7 +9,6 @@
 #include "drivers/video/vga.h"
 #include "ferrite/dirent.h"
 #include "memory/buddy_allocator/buddy.h"
-#include "sys/file/stat.h"
 #include "sys/process/process.h"
 #include "sys/signal/signal.h"
 #include "sys/timer/timer.h"
@@ -168,7 +167,7 @@ static void list_directory_contents(char const* path)
         printk("Something went wrong reading dir\n");
     }
 
-    // TODO: Close fd when syscall 6 is implemented
+    __asm__ volatile("int $0x80" : "=a"(fd) : "a"(6), "b"(fd) : "memory");
 }
 
 static void print_time(void)

--- a/src/fs/ext2/dir.c
+++ b/src/fs/ext2/dir.c
@@ -1,8 +1,5 @@
 #include "arch/x86/time/time.h"
 #include "drivers/block/device.h"
-#include "drivers/printk.h"
-#include "ferrite/dirent.h"
-#include "ferrite/types.h"
 #include "fs/ext2/ext2.h"
 #include "fs/vfs.h"
 #include "lib/math.h"
@@ -10,6 +7,9 @@
 #include "sys/file/file.h"
 #include "sys/file/stat.h"
 
+#include <ferrite/dirent.h>
+#include <ferrite/errno.h>
+#include <ferrite/types.h>
 #include <lib/string.h>
 
 static s32
@@ -20,8 +20,7 @@ ext2_dir_read(vfs_inode_t* inode, struct file* file, void* buff, int count)
     (void)buff;
     (void)count;
 
-    // return -EISDIR;
-    return -1;
+    return -EISDIR;
 }
 
 static s32
@@ -34,6 +33,9 @@ static struct file_operations ext2_dir_operations = {
     .write = NULL,
     .readdir = ext2_readdir,
     .read = ext2_dir_read,
+    .release = NULL,
+    .open = NULL,
+    .lseek = NULL,
 };
 
 struct inode_operations ext2_dir_inode_ops = {

--- a/src/sys/file/file.h
+++ b/src/sys/file/file.h
@@ -30,6 +30,7 @@ struct file_operations {
     int (*read)(struct vfs_inode*, struct file*, void*, int);
     int (*write)(struct vfs_inode*, struct file*, void const*, int);
 
+    int (*open)(struct vfs_inode*, struct file*);
     void (*release)(struct vfs_inode*, struct file*);
     int (*lseek)(struct vfs_inode*, struct file*, off_t, int);
 };


### PR DESCRIPTION
Implements the `close()` syscall and standardizes file operation structure definitions.

**Changes:**
- Moved `sys_close()` implementation to proper location in syscalls.c (was at bottom, now near `sys_open()`)
- Added `open` and `lseek` to `file_operations` struct for completeness
- Updated `ext2_dir_operations` to explicitly set all function pointers (including NULL for unimplemented ops)
- Changed `ext2_dir_read()` to return `-EISDIR` instead of generic `-1`