### PR TITLE
Add cat/echo commands and fix file I/O bugs

### DIFF
--- a/src/arch/x86/idt/syscalls.c
+++ b/src/arch/x86/idt/syscalls.c
@@ -44,7 +44,7 @@ SYSCALL_ATTR static s32 sys_read(s32 fd, void* buf, int count)
 SYSCALL_ATTR static s32 sys_write(s32 fd, void* buf, int count)
 {
     file_t* f = fd_get(fd);
-    if (!f || f->f_inode) {
+    if (!f || !f->f_inode) {
         return -1;
     }
 

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -104,6 +104,7 @@ static void echo_file(char const* args)
     }
 
     int ret;
+
     __asm__ volatile("int $0x80"
                      : "=a"(ret)
                      : "a"(SYS_WRITE), "b"(fd), "c"(text), "d"(text_len)


### PR DESCRIPTION
Adds basic file utilities and fixes critical file operation bugs.

**New Commands:**
- `cat <file>` - read and display file contents
- `echo <text> > <file>` - write text to file (with redirection support)

**Critical Fixes:**
- Fixed `sys_write()` inverted condition check (`!f->f_inode` → `!f->f_inode`)
- Fixed file size not persisting: `ext2_file_write()` now updates both `node->i_size` and `dir->i_size`
- Fixed reading garbage past EOF: added `bytes_remaining` check in `ext2_file_read()`
- Fixed file creation missing `S_IFREG` flag in `sys_open()`