### PR TITLE
Implement truncate and ftruncate syscalls

### DIFF
--- a/src/arch/x86/idt/syscalls.h
+++ b/src/arch/x86/idt/syscalls.h
@@ -35,6 +35,8 @@ enum syscalls_e {
     SYS_SIGNAL = 48,
     SYS_GETEUID = 49,
     SYS_READDIR = 89,
+    SYS_TRUNCATE = 92,
+    SYS_FTRUNCATE = 93,
     SYS_SOCKETCALL = 102,
     SYS_NANOSLEEP = 162,
 

--- a/src/fs/ext2/dir.c
+++ b/src/fs/ext2/dir.c
@@ -57,7 +57,7 @@ struct inode_operations ext2_dir_inode_operations = {
     //     NULL,                 /* readlink */
     //     NULL,                 /* follow_link */
     //     NULL,                 /* bmap */
-    //     ext2_truncate,        /* truncate */
+    .truncate = ext2_truncate,
     //     ext2_permission       /* permission */
 };
 

--- a/src/fs/ext2/ext2.h
+++ b/src/fs/ext2/ext2.h
@@ -201,6 +201,9 @@ extern struct inode_operations ext2_dir_inode_operations;
 /* file.c */
 extern struct inode_operations ext2_file_inode_operations;
 
+/* truncate.c */
+extern int ext2_truncate(vfs_inode_t*, off_t);
+
 inline int find_free_bit_in_bitmap(u8 const* bitmap, u32 size)
 {
     for (u32 i = 0; i < size; i += 1) {

--- a/src/fs/ext2/file.c
+++ b/src/fs/ext2/file.c
@@ -31,6 +31,7 @@ struct inode_operations ext2_file_inode_operations = {
     .lookup = NULL,
     .mkdir = NULL,
     .unlink = NULL,
+    .truncate = ext2_truncate,
 };
 
 int ext2_file_read(vfs_inode_t* node, file_t* file, void* buff, s32 count)

--- a/src/fs/ext2/truncate.c
+++ b/src/fs/ext2/truncate.c
@@ -1,0 +1,56 @@
+#include "arch/x86/time/time.h"
+#include "fs/ext2/ext2.h"
+#include "fs/stat.h"
+#include "fs/vfs.h"
+#include "lib/math.h"
+
+#include <ferrite/errno.h>
+#include <ferrite/types.h>
+
+int ext2_truncate(vfs_inode_t* node, off_t len)
+{
+    if (!node || !S_ISREG(node->i_mode)) {
+        return -EINVAL;
+    }
+
+    ext2_inode_t* ext2_node = node->u.i_ext2;
+    vfs_superblock_t* sb = node->i_sb;
+
+    if (len > (long)node->i_size) {
+        time_t now = getepoch();
+        node->i_size = len;
+        node->i_mtime = now;
+        node->i_ctime = now;
+
+        ext2_node->i_size = node->i_size;
+        ext2_node->i_mtime = node->i_mtime;
+        ext2_node->i_ctime = node->i_ctime;
+
+        return node->i_sb->s_op->write_inode(node);
+    }
+
+    u32 blocks_needed = CEIL_DIV(len, sb->s_blocksize);
+
+    for (u32 i = blocks_needed; i < 12 && ext2_node->i_block[i]; i += 1) {
+        ext2_free_block(node, ext2_node->i_block[i]);
+        ext2_node->i_block[i] = 0;
+    }
+
+    time_t now = getepoch();
+    node->i_size = len;
+    node->i_mtime = now;
+    node->i_ctime = now;
+
+    ext2_node->i_size = node->i_size;
+    ext2_node->i_mtime = node->i_mtime;
+    ext2_node->i_ctime = node->i_ctime;
+
+    u32 allocated = 0;
+    for (u32 i = 0; i < 12 && ext2_node->i_block[i]; i += 1) {
+        allocated += 1;
+    }
+
+    ext2_node->i_blocks = (allocated * sb->s_blocksize) / 512;
+
+    return node->i_sb->s_op->write_inode(node);
+}

--- a/src/fs/vfs.h
+++ b/src/fs/vfs.h
@@ -76,7 +76,7 @@ struct inode_operations {
     int (*rmdir)(vfs_inode_t*, char const*, int);
 
     int (*unlink)(vfs_inode_t*, char const*, int);
-    void (*truncate)(vfs_inode_t*);
+    int (*truncate)(vfs_inode_t*, off_t);
 };
 
 vfs_inode_t* inode_get(vfs_superblock_t* sb, unsigned long ino);


### PR DESCRIPTION
Adds file truncation support for resizing files.

**Implementation:**
- `sys_truncate(path, len)`: Truncate by path
- `sys_ftruncate(fd, len)`: Truncate by file descriptor
- `ext2_truncate()`: Growing (updates size) and shrinking (frees blocks)
- Updates mtime/ctime and recalculates block count