### PR TITLE
Add execve prototype

### DIFF
--- a/src/arch/x86/idt/syscalls.h
+++ b/src/arch/x86/idt/syscalls.h
@@ -3,6 +3,8 @@
 
 #include "arch/x86/idt/idt.h"
 
+#define USER_CS 0x23
+
 #define SYSCALL_ATTR \
     __attribute__((target("general-regs-only"), warn_unused_result))
 
@@ -23,6 +25,7 @@ enum syscalls_e {
     SYS_CLOSE = 6,
     SYS_WAITPID = 7,
     SYS_UNLINK = 10,
+    SYS_EXECVE = 11,
     SYS_CHDIR = 12,
     SYS_TIME = 13,
     SYS_STAT = 18,

--- a/src/fs/exec.c
+++ b/src/fs/exec.c
@@ -1,0 +1,203 @@
+#include "fs/exec.h"
+#include "arch/x86/idt/idt.h"
+#include "ferrite/types.h"
+#include "fs/stat.h"
+#include "fs/vfs.h"
+#include "memory/page.h"
+#include "sys/file/file.h"
+#include "sys/process/process.h"
+
+#include <ferrite/errno.h>
+#include <lib/stdlib.h>
+#include <lib/string.h>
+#include <memory/consts.h>
+#include <sys/file/fcntl.h>
+
+/* Formats */
+
+/* NOTE: Should only implement ELF, not a.out, since it is obsolete */
+
+// extern int load_aout_binary(binpgm_t*, registers_t*);
+// extern int load_aout_library(int);
+
+binfmt_t supported_formats[] = { { NULL, NULL } };
+
+/* Private */
+
+static int count(char const* const* array)
+{
+    int i = 0;
+    if (!array) {
+        return 0;
+    }
+
+    while (array[i]) {
+        i++;
+    }
+
+    return i;
+}
+
+static unsigned long copy_strings(
+    int argc,
+    char const* const argv[],
+    unsigned long* page,
+    unsigned long p
+)
+{
+    for (int i = argc - 1; i >= 0; i += 1) {
+        char const* str = (char*)argv[i];
+        size_t len = strlen(str) + 1;
+
+        if (p < len) {
+            return 0;
+        }
+
+        p -= len;
+
+        for (size_t j = 0; j < len; j += 1) {
+            int page_index = (p + j) / PAGE_SIZE;
+            int offset = (p + j) % PAGE_SIZE;
+
+            if (!page[page_index]) {
+                page[page_index] = (unsigned long)get_free_page();
+                if (!page[page_index]) {
+                    return 0;
+                }
+            }
+
+            ((char*)page[page_index])[offset] = str[j];
+        }
+    }
+
+    return p;
+}
+
+static int read_exec(vfs_inode_t* node, int offset, char* addr, int count)
+{
+    if (count > 128 || (u32)offset > node->i_size) {
+        return -EINVAL;
+    }
+
+    file_t file;
+    int result = -ENOEXEC;
+
+    if (!node->i_op || !node->i_op->default_file_ops) {
+        goto end_readexec;
+    }
+
+    file.f_mode = FMODE_READ;
+    file.f_flags = 0;
+    file.f_count = 1;
+    file.f_inode = node;
+    file.f_pos = 0;
+    file.f_op = node->i_op->default_file_ops;
+
+    if (file.f_op->open) {
+        if (file.f_op->open(node, &file))
+            goto end_readexec;
+    }
+
+    if (!file.f_op || !file.f_op->read) {
+        goto close_readexec;
+    }
+
+    if (file.f_op->lseek) {
+        if (file.f_op->lseek(node, &file, offset, SEEK_SET) != offset) {
+            goto close_readexec;
+        }
+    } else {
+        file.f_pos = offset;
+    }
+
+    result = file.f_op->read(node, &file, addr, count);
+
+close_readexec:
+    if (file.f_op->release) {
+        file.f_op->release(node, &file);
+    }
+
+end_readexec:
+    return result;
+}
+
+/* Public */
+
+int do_execve(
+    char const* filename,
+    char const* const* argv,
+    char const* const* envp
+)
+{
+    int retval = 0;
+
+    binfmt_t* fmt = supported_formats;
+    binpgm_t bin = { 0 };
+
+    bin.b_p = PAGE_SIZE * MAX_ARG_PAGES - 4;
+    for (int i = 0; i < MAX_ARG_PAGES; i += 1) {
+        bin.b_page[i] = 0;
+    }
+
+    bin.b_node = vfs_lookup(myproc()->root, filename);
+    if (!bin.b_node) {
+        return -ENOENT;
+    }
+
+    bin.b_filename = (char*)filename;
+    bin.argc = count(argv);
+    bin.envc = count(envp);
+
+    if (!S_ISREG(bin.b_node->i_mode)) {
+        retval = -EACCES;
+        goto exec_error;
+    }
+    if (!bin.b_node->i_sb) {
+        retval = -EACCES;
+        goto exec_error;
+    }
+
+    memset(bin.b_buf, 0, sizeof(bin.b_buf));
+    retval = read_exec(bin.b_node, 0, bin.b_buf, 128);
+    if (retval < 0) {
+        goto exec_error;
+    }
+
+    bin.b_p = copy_strings(bin.envc, envp, bin.b_page, bin.b_p);
+    if (bin.b_p == 0) {
+        retval = -E2BIG;
+        goto exec_error;
+    }
+
+    bin.b_p = copy_strings(bin.argc, argv, bin.b_page, bin.b_p);
+    if (bin.b_p == 0) {
+        retval = -E2BIG;
+        goto exec_error;
+    }
+
+    do {
+        if (!fmt->load_binary) {
+            break;
+        }
+
+        // retval = fmt->load_binary(&bin, regs);
+        // if (retval == 0) {
+        //     inode_put(bin.b_node);
+        //
+        //     return 0;
+        // }
+
+        fmt++;
+    } while (retval == -ENOEXEC);
+
+exec_error:
+    inode_put(bin.b_node);
+
+    for (int i = 0; i < MAX_ARG_PAGES; i++) {
+        if (bin.b_page[i]) {
+            free_page((void*)bin.b_page[i]);
+        }
+    }
+
+    return retval;
+}

--- a/src/fs/exec.h
+++ b/src/fs/exec.h
@@ -1,0 +1,44 @@
+#ifndef _BIN_PROGRAMS_H
+#define _BIN_PROGRAMS_H
+
+#include "arch/x86/idt/idt.h"
+#include "fs/vfs.h"
+
+/*
+ * From Linux 1.0:
+ * https://elixir.bootlin.com/linux/1.0.9/source/include/linux/binfmts.h#L16
+ *
+ * MAX_ARG_PAGES defines the number of pages allocated for arguments
+ * and envelope for the new program. 32 should suffice, this gives
+ * a maximum env+arg of 128kB !
+ */
+#define MAX_ARG_PAGES 32
+
+/*
+ * This structure is used to hold the arguments that are used when loading
+ * binaries.
+ */
+typedef struct binpgm {
+    char b_buf[128];
+
+    unsigned long b_page[MAX_ARG_PAGES];
+    unsigned long b_p;
+
+    vfs_inode_t* b_node;
+
+    int e_uid, e_gid;
+    int argc, envc;
+
+    int b_sh_bang;
+    char* b_filename; /* Name of binary */
+} binpgm_t;
+
+typedef struct binfmt {
+    int (*load_binary)(binpgm_t*, registers_t*);
+    int (*load_shlib)(int);
+} binfmt_t;
+
+/* exec.c */
+int do_execve(char const*, char const* const*, char const* const*);
+
+#endif

--- a/src/memory/page.c
+++ b/src/memory/page.c
@@ -1,10 +1,10 @@
 #include "arch/x86/memlayout.h"
 #include "drivers/printk.h"
-#include "lib/string.h"
 #include "memory/buddy_allocator/buddy.h"
 #include "memory/consts.h"
 
 #include <ferrite/types.h>
+#include <lib/string.h>
 
 /*
  * Allocates a single 4KB page from the buddy allocator, converts it to a

--- a/src/sys/file/fcntl.h
+++ b/src/sys/file/fcntl.h
@@ -3,6 +3,10 @@
 
 #include <ferrite/types.h>
 
+#define SEEK_SET 0
+#define SEEK_CUR 1
+#define SEEK_END 2
+
 #define O_ACCMODE 0003
 #define O_RDONLY 00
 #define O_WRONLY 01


### PR DESCRIPTION
Adds foundational code for `execve()` syscall, currently disabled pending ELF loader implementation.